### PR TITLE
background iterator for readpairs

### DIFF
--- a/src/background_iterator.rs
+++ b/src/background_iterator.rs
@@ -1,5 +1,5 @@
-use std::sync::mpsc::{Receiver, sync_channel};
 use std;
+use std::sync::mpsc::{sync_channel, Receiver};
 use std::thread;
 
 /// Execute an iterator on a worker thread, which can work ahead a configurable number of items.

--- a/src/background_iterator.rs
+++ b/src/background_iterator.rs
@@ -1,11 +1,12 @@
 use std;
 use std::sync::mpsc::{sync_channel, Receiver};
-use std::thread;
+use std::thread::{JoinHandle, spawn};
 
 /// Execute an iterator on a worker thread, which can work ahead a configurable number of items.
 pub struct BackgroundIterator<T> {
     rx: Receiver<Option<T>>,
     done: bool,
+    handle: Option<JoinHandle<()>>,
 }
 
 impl<T: Send> Iterator for BackgroundIterator<T> {
@@ -22,10 +23,31 @@ impl<T: Send> Iterator for BackgroundIterator<T> {
                 self.done = true;
                 None
             }
-
-            // if the producer thread dies, the iterator
-            // silently exits, without an error.
-            Err(_) => None,
+            // if the producer thread dies, then the sender thread must have panicked
+            // propagate the panic, otherwise we will silently continue with likely incomplete results
+            Err(_) => {
+                self.done = true;
+                let r = self.handle.take().unwrap().join();
+                match r {
+                    Ok(()) => {
+                        // this state should be unreachable,
+                        // but presumably benign if we get here
+                        None
+                    }
+                    Err(e) => {
+                        // sender panicked - we will re-panic the panic.
+                        // need to do a little dance here to get the panic message
+                        let msg = match e.downcast_ref::<&'static str>() {
+                            Some(s) => s.to_string(),                            
+                            None => match e.downcast_ref::<String>() {
+                                Some(s) => s.clone(),
+                                None => "unknown panic on BackgroundIterator worker thread".to_string(),
+                            },
+                        };                        
+                        panic!(msg);
+                    }
+                }
+            }
         }
     }
 }
@@ -39,7 +61,7 @@ impl<T: 'static + Send> BackgroundIterator<T> {
         max_read_ahead: usize,
     ) -> BackgroundIterator<T> {
         let (tx, rx) = sync_channel::<Option<T>>(max_read_ahead);
-        let _ = thread::spawn(move || {
+        let handle = spawn(move || {
             for item in itr {
                 if tx.send(Some(item)).is_err() {
                     return;
@@ -49,6 +71,77 @@ impl<T: 'static + Send> BackgroundIterator<T> {
             tx.send(None).unwrap();
         });
 
-        BackgroundIterator { rx, done: false }
+        BackgroundIterator { 
+            rx, 
+            handle: Some(handle), 
+            done: false }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    #[should_panic]
+    fn panic_bg_iter() {
+        let v = vec![0,1,2,3,4,5,6,7,8,9];
+
+        let iter = (0..11usize).map(move |i| {
+            if v[i] == 5 {
+                panic!("simulated panic");
+            }
+            v[i]
+        });
+
+        let bg_iter = BackgroundIterator::new(iter, 5);
+
+        let mut sum = 0;
+        for v in bg_iter {
+            sum += v;
+        }
+        println!("sum :{}", sum);
+    }
+
+    #[test]
+    fn bg_iter() {
+        let v = vec![5; 10];
+
+        let iter = (0..10usize).map(move |i| v[i]);
+
+        let bg_iter = BackgroundIterator::new(iter, 5);
+
+        let mut sum = 0;
+        for v in bg_iter {
+            sum += v;
+        }
+
+        assert_eq!(sum, 50);
+    }
+
+    #[test]
+    fn slow_reader_buffer() {
+        let n_send = 1_000_000;
+
+        // big iterator with lots of buffering
+        let iter = (0..n_send).map(|i| i*i);
+        let bg_iter = BackgroundIterator::new(iter, n_send >> 2);
+
+
+        // slow reader -- the sender thread will complete before the reading is complete
+        // make sure we get all the items
+
+        let mut n_read = 0;
+        for v in bg_iter {
+            assert_eq!(v, n_read*n_read);
+            n_read += 1;
+
+            // make sure the reader goes slowly
+            if n_read % 50_000 == 0 {
+                std::thread::sleep(std::time::Duration::from_millis(1));
+            }
+        }
+
+        assert_eq!(n_send, n_read);
     }
 }

--- a/src/background_iterator.rs
+++ b/src/background_iterator.rs
@@ -1,0 +1,54 @@
+use std::sync::mpsc::{Receiver, sync_channel};
+use std;
+use std::thread;
+
+/// Execute an iterator on a worker thread, which can work ahead a configurable number of items.
+pub struct BackgroundIterator<T> {
+    rx: Receiver<Option<T>>,
+    done: bool,
+}
+
+impl<T: Send> Iterator for BackgroundIterator<T> {
+    type Item = T;
+
+    fn next(&mut self) -> Option<T> {
+        if self.done {
+            return None;
+        }
+
+        match self.rx.recv() {
+            Ok(Some(v)) => Some(v),
+            Ok(None) => {
+                self.done = true;
+                None
+            }
+
+            // if the producer thread dies, the iterator
+            // silently exits, without an error.
+            Err(_) => None,
+        }
+    }
+}
+
+impl<T: 'static + Send> BackgroundIterator<T> {
+    /// Iterate through `itr` on a newly created thread, and send items back to the returned
+    /// `BackgroundIterator` for consumption on the calling thread. The worker thread will
+    /// continue to produce elements until it is `max_read_ahead` items ahead of the consumer iterator.
+    pub fn new<I: 'static + Send + Iterator<Item = T>>(
+        itr: I,
+        max_read_ahead: usize,
+    ) -> BackgroundIterator<T> {
+        let (tx, rx) = sync_channel::<Option<T>>(max_read_ahead);
+        let _ = thread::spawn(move || {
+            for item in itr {
+                if tx.send(Some(item)).is_err() {
+                    return;
+                };
+            }
+
+            tx.send(None).unwrap();
+        });
+
+        BackgroundIterator { rx, done: false }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ pub use crate::sseq::SSeq;
 pub use fastq::OwnedRecord;
 pub use fastq::Record;
 
-use crate::read_pair_iter::{InputFastqs, AnyReadPairIter, ReadPairIter};
+use crate::read_pair_iter::{AnyReadPairIter, InputFastqs, ReadPairIter};
 use crate::sseq::{HammingIterOpt, SSeqOneHammingIter};
 use failure::{format_err, Error};
 use itertools::Itertools;

--- a/src/read_pair_iter.rs
+++ b/src/read_pair_iter.rs
@@ -508,7 +508,8 @@ impl Iterator for ReadPairIter {
     }
 }
 
-type BackgroundReadPairIter = crate::background_iterator::BackgroundIterator<Result<ReadPair, FastqError>>;
+type BackgroundReadPairIter =
+    crate::background_iterator::BackgroundIterator<Result<ReadPair, FastqError>>;
 
 pub(crate) enum AnyReadPairIter {
     Direct(ReadPairIter),


### PR DESCRIPTION
puts the ungzipping of the input fastqs on another thread, saving ~35% of wall time on MAKE_SHARD. @adam-azarchs could you take a look at the BackgroundIterator stuff?