### PR TITLE
Defer handling of incomplete RnaRead to the user of FastqProcessor

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastq_set"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"


### PR DESCRIPTION
This should help us track unprocessed reads in Cellranger. 