### PR TITLE
Use generic array for flexible SSeq/SQuality sizes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -520,6 +520,7 @@ dependencies = [
  "fastq",
  "file_diff",
  "flate2",
+ "generic-array",
  "glob",
  "itertools",
  "lazy_static",
@@ -583,6 +584,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
+]
+
+[[package]]
+name = "generic-array"
+version = "0.14.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
+dependencies = [
+ "typenum",
+ "version_check",
 ]
 
 [[package]]
@@ -1507,6 +1518,12 @@ name = "triple_accel"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13fef44d8e806b2203c290d3cf081a1bb683c61715e8244a9591fecd017066b5"
+
+[[package]]
+name = "typenum"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unescape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ itertools = ">=0.8"
 lz4 = "*"
 fastq = "^0.6"
 bio = ">=0.29"
+generic-array = "0.14.4"
 
 [dev-dependencies]
 time = "*"

--- a/src/array.rs
+++ b/src/array.rs
@@ -1,0 +1,244 @@
+pub use generic_array::typenum;
+use generic_array::{ArrayLength, GenericArray};
+use serde::de::{self, Visitor};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::borrow::Borrow;
+use std::fmt;
+use std::hash::{Hash, Hasher};
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+pub trait ArrayContent {
+    fn validate_bytes(bytes: &[u8]);
+    fn expected_contents() -> &'static str;
+}
+
+/// Fixed-sized container for a short DNA sequence or quality.
+/// The capacity is determined by the type `N` and the contents are validates based on type `T`
+/// Typically used as a convenient container for barcode or UMI sequences.
+#[derive(Clone, Copy, PartialOrd, Ord, Eq)]
+pub struct ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    bytes: GenericArray<u8, N>,
+    length: u8,
+    phantom: PhantomData<T>,
+}
+
+impl<N, T> ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    /// Create a new ByteArray from the given byte slice
+    /// The byte slice should contain only valid alphabets as defined by ArrayContent trait
+    /// otherwise this function will panic
+    pub fn new(src: &[u8]) -> Self {
+        let mut bytes: GenericArray<u8, N> = GenericArray::default();
+
+        assert!(src.len() <= bytes.len());
+        T::validate_bytes(src);
+
+        for (l, r) in bytes.as_mut_slice().iter_mut().zip(src.iter()) {
+            *l = *r;
+        }
+        ByteArray {
+            length: src.len() as u8,
+            bytes,
+            phantom: PhantomData,
+        }
+    }
+
+    /// Returns a byte slice of the contents.
+    pub fn as_bytes(&self) -> &[u8] {
+        &self.bytes.as_slice()[0..self.length as usize]
+    }
+
+    /// Returns a str of the contents.
+    pub fn as_str(&self) -> &str {
+        std::str::from_utf8(self.as_bytes()).unwrap()
+    }
+
+    /// Returns a mutable byte slice of the contents.
+    pub fn as_mut_bytes(&mut self) -> &mut [u8] {
+        &mut self.bytes.as_mut_slice()[0..self.length as usize]
+    }
+
+    /// Returns the length of this sequence, in bytes.
+    pub fn len(self) -> usize {
+        self.length as usize
+    }
+
+    /// Returns an iterator over the bytes.
+    pub fn iter(&self) -> std::slice::Iter<u8> {
+        self.as_bytes().iter()
+    }
+}
+
+impl<N, T> fmt::Display for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl<N, T> fmt::Debug for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self, f)
+    }
+}
+
+impl<N, T> Index<usize> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    type Output = u8;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        if index >= self.length as usize {
+            panic!("index out of bounds")
+        }
+
+        &self.bytes[index]
+    }
+}
+
+impl<N, T> IndexMut<usize> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        if index >= self.length as usize {
+            panic!("index out of bounds")
+        }
+        &mut self.bytes[index]
+    }
+}
+
+impl<N, T> AsRef<[u8]> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn as_ref(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<N, T> Into<String> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn into(self) -> String {
+        String::from(self.as_str())
+    }
+}
+
+impl<N, T> Borrow<[u8]> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn borrow(&self) -> &[u8] {
+        self.as_bytes()
+    }
+}
+
+impl<N, T> Hash for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        self.as_bytes().hash(state);
+    }
+}
+
+impl<N, T> PartialEq for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn eq(&self, other: &Self) -> bool {
+        self.as_bytes() == other.as_bytes()
+    }
+}
+
+impl<N, T> Serialize for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de, N, T> Deserialize<'de> for ByteArray<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        deserializer.deserialize_str(ByteArrayVisitor {
+            phantom_n: PhantomData,
+            phantom_t: PhantomData,
+        })
+    }
+}
+
+struct ByteArrayVisitor<N, T> {
+    phantom_n: PhantomData<N>,
+    phantom_t: PhantomData<T>,
+}
+
+impl<'de, N, T> Visitor<'de> for ByteArrayVisitor<N, T>
+where
+    N: ArrayLength<u8>,
+    N::ArrayType: Copy,
+    T: ArrayContent,
+{
+    type Value = ByteArray<N, T>;
+
+    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+        formatter.write_str(T::expected_contents())
+    }
+
+    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
+    where
+        E: de::Error,
+    {
+        Ok(ByteArray::new(value.as_bytes()))
+    }
+}

--- a/src/array.rs
+++ b/src/array.rs
@@ -15,7 +15,7 @@ pub trait ArrayContent {
 
 /// Fixed-sized container for a short DNA sequence or quality.
 /// The capacity is determined by the type `N` and the contents are validates based on type `T`
-/// Typically used as a convenient container for barcode or UMI sequences.
+/// Typically used as a convenient container for barcode or UMI sequences or quality.
 #[derive(Clone, Copy, PartialOrd, Ord, Eq)]
 pub struct ByteArray<N, T>
 where
@@ -71,6 +71,11 @@ where
     /// Returns the length of this sequence, in bytes.
     pub fn len(self) -> usize {
         self.length as usize
+    }
+
+    /// Returns true if self has a length of zero bytes.
+    pub fn is_empty(self) -> bool {
+        self.length == 0
     }
 
     /// Returns an iterator over the bytes.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 use fastq;
 
 pub mod adapter_trimmer;
+pub mod array;
 pub mod background_iterator;
 pub mod filenames;
 pub mod illumina_header_info;

--- a/src/squality.rs
+++ b/src/squality.rs
@@ -2,167 +2,41 @@
 
 //! Sized, stack-allocated container for a short quality string.
 
-use serde::de::{self, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Borrow;
-use std::hash::{Hash, Hasher};
+use crate::array::{typenum, ArrayContent, ByteArray};
 use std::iter::Iterator;
-use std::ops::{Index, IndexMut};
 use std::str;
 
-/// Ensure that the input byte slice contains only valid quality characters, and panic otherwise.
-pub fn ensure_valid_quality(seq: &[u8]) {
-    for (i, &c) in seq.iter().enumerate() {
-        let q = c as i16 - 33;
-        if q < 0 || q >= 42 {
-            panic!(
-                "Invalid quality value {} ASCII character {} at position {}",
-                q, c, i
-            );
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub struct SQualityContents;
+
+impl ArrayContent for SQualityContents {
+    /// Ensure that the input byte slice contains only valid quality characters, and panic
+    /// otherwise.
+    fn validate_bytes(seq: &[u8]) {
+        for (i, &c) in seq.iter().enumerate() {
+            let q = c as i16 - 33;
+            if q < 0 || q >= 42 {
+                panic!(
+                    "Invalid quality value {} ASCII character {} at position {}",
+                    q, c, i
+                );
+            }
         }
     }
+    fn expected_contents() -> &'static str {
+        "A valid read quality value"
+    }
 }
+
+/// Fixed-sized container for a short quality string, with capacity determined by the type `N`.
+/// Used as a convenient container for a barcode or UMI quality string.
+/// An `SQualityGen` is guaranteed to contain only valid quality characters.
+pub type SQualityGen<N> = ByteArray<N, SQualityContents>;
 
 /// Fixed-sized container for a short quality string, up to 23bp in length.
 /// Used as a convenient container for a barcode or UMI quality string.
 /// An `SQuality` is guaranteed to contain only valid quality characters.
-#[derive(Clone, Copy, PartialOrd, Ord, Eq)]
-pub struct SQuality {
-    pub(crate) bytes: [u8; 23],
-    pub(crate) length: u8,
-}
-
-impl SQuality {
-    /// Create a new SQuality from the given byte slice
-    /// The byte slice must contain only valid quality characters and panics otherwise.
-    pub fn new(s: &[u8]) -> SQuality {
-        assert!(s.len() <= 23);
-        ensure_valid_quality(s);
-
-        let mut bytes = [0u8; 23];
-        bytes[0..s.len()].copy_from_slice(&s);
-
-        SQuality {
-            length: s.len() as u8,
-            bytes,
-        }
-    }
-
-    /// Returns a byte slice of self.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.bytes[0..self.length as usize]
-    }
-
-    /// Returns the length of self.
-    pub fn len(self) -> usize {
-        self.length as usize
-    }
-
-    /// Returns true if self has a length of zero bytes.
-    pub fn is_empty(self) -> bool {
-        self.length == 0
-    }
-}
-
-impl Index<usize> for SQuality {
-    type Output = u8;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        if index >= self.length as usize {
-            panic!("index out of bounds")
-        }
-
-        &self.bytes[index]
-    }
-}
-
-impl IndexMut<usize> for SQuality {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        if index >= self.length as usize {
-            panic!("index out of bounds")
-        }
-
-        &mut self.bytes[index]
-    }
-}
-
-impl AsRef<[u8]> for SQuality {
-    fn as_ref(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl Into<String> for SQuality {
-    fn into(self) -> String {
-        String::from(str::from_utf8(self.as_bytes()).unwrap())
-    }
-}
-
-impl Borrow<[u8]> for SQuality {
-    fn borrow(&self) -> &[u8] {
-        self.as_bytes()
-    }
-}
-
-impl Hash for SQuality {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.as_bytes().hash(state);
-    }
-}
-
-impl PartialEq for SQuality {
-    fn eq(&self, other: &SQuality) -> bool {
-        self.as_bytes() == other.as_bytes()
-    }
-}
-
-use std::fmt;
-
-impl fmt::Display for SQuality {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(str::from_utf8(self.as_bytes()).unwrap())
-    }
-}
-impl fmt::Debug for SQuality {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl Serialize for SQuality {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_bytes(self.as_bytes())
-    }
-}
-
-impl<'de> Deserialize<'de> for SQuality {
-    fn deserialize<D>(deserializer: D) -> Result<SQuality, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_bytes(SQualityVisitor)
-    }
-}
-
-struct SQualityVisitor;
-
-impl<'de> Visitor<'de> for SQualityVisitor {
-    type Value = SQuality;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("an integer between -2^31 and 2^31")
-    }
-
-    fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(SQuality::new(value))
-    }
-}
+pub type SQuality = SQualityGen<typenum::U23>;
 
 #[cfg(test)]
 mod squality_test {

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -2,60 +2,39 @@
 
 //! Sized, stack-allocated container for a short DNA sequence.
 
-use serde::de::{self, Visitor};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use std::borrow::Borrow;
-use std::hash::{Hash, Hasher};
+use crate::array::{typenum, ArrayContent, ByteArray};
 use std::iter::Iterator;
-use std::ops::{Index, IndexMut};
 use std::str;
 
 const UPPER_ACGTN: &[u8; 5] = b"ACGTN";
 const N_BASE_INDEX: usize = 4;
 
-/// Make sure that the input byte slice contains only
-/// "ACGTN" characters. Panics otherwise with an error
-/// message describing the position of the first character
-/// that is not an ACGTN.
-pub fn ensure_upper_case_acgtn(seq: &[u8]) {
-    for (i, &s) in seq.iter().enumerate() {
-        if !UPPER_ACGTN.iter().any(|&c| c == s) {
-            panic!("Non ACGTN character {} at position {}", s, i);
-        };
+#[derive(Clone, Copy, PartialOrd, Ord, PartialEq, Eq)]
+pub struct SSeqContents;
+
+impl ArrayContent for SSeqContents {
+    /// Make sure that the input byte slice contains only
+    /// "ACGTN" characters. Panics otherwise with an error
+    /// message describing the position of the first character
+    /// that is not an ACGTN.
+    fn validate_bytes(seq: &[u8]) {
+        for (i, &s) in seq.iter().enumerate() {
+            if !UPPER_ACGTN.iter().any(|&c| c == s) {
+                panic!("Non ACGTN character {} at position {}", s, i);
+            };
+        }
+    }
+    fn expected_contents() -> &'static str {
+        "An [ACGTN]* string"
     }
 }
 
 /// Fixed-sized container for a short DNA sequence, up to 23bp in length.
 /// Used as a convenient container for barcode or UMI sequences.
 /// An `SSeq` is guaranteed to contain only "ACGTN" alphabets
-#[derive(Clone, Copy, PartialOrd, Ord, Eq)]
-pub struct SSeq {
-    pub(crate) sequence: [u8; 23],
-    pub(crate) length: u8,
-}
+pub type SSeq = ByteArray<typenum::U23, SSeqContents>;
 
 impl SSeq {
-    /// Create a new SSeq from the given byte slice
-    /// The byte slice should contain only "ACGTN" (upper case) alphabets,
-    /// otherwise this function will panic
-    pub fn new(seq: &[u8]) -> SSeq {
-        assert!(seq.len() <= 23);
-        ensure_upper_case_acgtn(seq);
-
-        let mut sequence = [0u8; 23];
-        sequence[0..seq.len()].copy_from_slice(&seq);
-
-        SSeq {
-            length: seq.len() as u8,
-            sequence,
-        }
-    }
-
-    /// Returns a byte slice of this SSeq's contents.
-    pub fn as_bytes(&self) -> &[u8] {
-        &self.sequence[0..self.length as usize]
-    }
-
     /// Returns a byte slice of this sequence's contents.
     /// A synonym for as_bytes().
     pub fn seq(&self) -> &[u8] {
@@ -65,22 +44,12 @@ impl SSeq {
     /// Returns a byte slice of this sequence's contents.
     /// A synonym for as_bytes().
     pub fn seq_mut(&mut self) -> &mut [u8] {
-        &mut self.sequence[0..self.length as usize]
-    }
-
-    /// Returns the length of this sequence, in bytes.
-    pub fn len(self) -> usize {
-        self.length as usize
+        self.as_mut_bytes()
     }
 
     /// Returns true if this sequence has a length of zero, and false otherwise.
     pub fn is_empty(self) -> bool {
-        self.length == 0
-    }
-
-    /// Returns an iterator over this sequence.
-    pub fn iter(&self) -> std::slice::Iter<u8> {
-        self.sequence[..self.length as usize].iter()
+        self.len() == 0
     }
 
     /// Returns true if this sequence contains an N.
@@ -91,12 +60,12 @@ impl SSeq {
     /// Returns true if this sequence is a homopolymer.
     pub fn is_homopolymer(&self) -> bool {
         assert!(!self.is_empty());
-        self.iter().all(|&c| c == self.sequence[0])
+        self.iter().all(|&c| c == self.seq()[0])
     }
 
     /// Returns true if the last n characters of this sequence are the specified homopolymer.
     pub fn has_homopolymer_suffix(&self, c: u8, n: usize) -> bool {
-        self.length as usize >= n && self.iter().rev().take(n).all(|&x| x == c)
+        self.len() as usize >= n && self.iter().rev().take(n).all(|&x| x == c)
     }
 
     /// Returns true if the last n characters of this sequence are T.
@@ -107,10 +76,11 @@ impl SSeq {
     /// Returns a 2-bit encoding of this sequence.
     pub fn encode_2bit_u32(self) -> u32 {
         let mut res: u32 = 0;
-        assert!(self.length < 16);
+        assert!(self.len() < 16);
 
-        for (bit_pos, str_pos) in (0..self.length).rev().enumerate() {
-            let byte: u32 = match self.sequence[str_pos as usize] {
+        let seq = self.seq();
+        for (bit_pos, str_pos) in (0..self.len()).rev().enumerate() {
+            let byte: u32 = match seq[str_pos as usize] {
                 b'A' => 0,
                 b'C' => 1,
                 b'G' => 2,
@@ -189,110 +159,6 @@ impl Iterator for SSeqOneHammingIter {
             self.chars_index += 1;
             Some(next_sseq)
         }
-    }
-}
-
-impl Index<usize> for SSeq {
-    type Output = u8;
-
-    fn index(&self, index: usize) -> &Self::Output {
-        if index >= self.length as usize {
-            panic!("index out of bounds")
-        }
-
-        &self.sequence[index]
-    }
-}
-
-impl IndexMut<usize> for SSeq {
-    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-        if index >= self.length as usize {
-            panic!("index out of bounds")
-        }
-
-        &mut self.sequence[index]
-    }
-}
-
-impl AsRef<[u8]> for SSeq {
-    fn as_ref(&self) -> &[u8] {
-        self.seq()
-    }
-}
-
-impl Into<String> for SSeq {
-    fn into(self) -> String {
-        String::from(str::from_utf8(self.seq()).unwrap())
-    }
-}
-
-impl Borrow<[u8]> for SSeq {
-    fn borrow(&self) -> &[u8] {
-        self.seq()
-    }
-}
-
-impl Hash for SSeq {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        self.seq().hash(state);
-    }
-}
-
-impl PartialEq for SSeq {
-    fn eq(&self, other: &SSeq) -> bool {
-        self.seq() == other.seq()
-    }
-}
-
-use std::fmt;
-
-impl fmt::Display for SSeq {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut s = String::new();
-        for pos in 0..self.len() {
-            s.push(self.sequence[pos] as char);
-        }
-        write!(f, "{}", s)
-    }
-}
-impl fmt::Debug for SSeq {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::Display::fmt(&self, f)
-    }
-}
-
-impl Serialize for SSeq {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        serializer.serialize_str(std::str::from_utf8(self.seq()).unwrap())
-    }
-}
-
-impl<'de> Deserialize<'de> for SSeq {
-    fn deserialize<D>(deserializer: D) -> Result<SSeq, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        deserializer.deserialize_str(SSeqVisitor)
-    }
-}
-
-struct SSeqVisitor;
-
-impl<'de> Visitor<'de> for SSeqVisitor {
-    type Value = SSeq;
-
-    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("An [ACGTN]* string")
-    }
-
-    fn visit_str<E>(self, value: &str) -> Result<Self::Value, E>
-    where
-        E: de::Error,
-    {
-        Ok(SSeq::new(value.as_bytes()))
     }
 }
 


### PR DESCRIPTION
- Define a struct `ByteArray<N, T>` where `N` controls the lengths of the inner array (based on `generic-array` crate) and `T` determines the validation
- Define generic containers for short sequence and short quality
```
pub type SSeqGen<N> = ByteArray<N, SSeqContents>;
pub type SQualityGen<N> = ByteArray<N, SQualityContents>;
```
- `SSeq` and `SQuality` becomes:
```
pub type SSeq = SSeqGen<typenum::U23>;
pub type SQuality = SQualityGen<typenum::U23>;
```
- Makes it trivial to define `SSeq/SQuality` containers of other sizes
- This also gets rid of the duplication of `SSeq` impls for `SQuality`