### PR TITLE
Use const generics in place of generic array

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.49.0
+          toolchain: 1.51.0
           components: rustfmt
       - name: Print cargo version
-        run: rustup default 1.49.0 && cargo --version
+        run: rustup default 1.51.0 && cargo --version
       - name: Checkout Git repository
         uses: actions/checkout@master
       - name: Check Rust formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -518,7 +518,7 @@ dependencies = [
 
 [[package]]
 name = "fastq_set"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "ahash",
  "bincode",
@@ -529,7 +529,6 @@ dependencies = [
  "fastq",
  "file_diff",
  "flate2",
- "generic-array",
  "glob",
  "itertools",
  "lazy_static",
@@ -593,16 +592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "generic-array"
-version = "0.14.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "501466ecc8a30d1d3b7fc9229b122b2ce8ed6e9d9223f1138d4babb253e51817"
-dependencies = [
- "typenum",
- "version_check",
 ]
 
 [[package]]
@@ -1517,12 +1506,6 @@ name = "triple_accel"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622b09ce2fe2df4618636fb92176d205662f59803f39e70d1c333393082de96c"
-
-[[package]]
-name = "typenum"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "373c8a200f9e67a0c95e62a4f52fbf80c23b4381c05a17845531982fa99e6b33"
 
 [[package]]
 name = "unescape"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastq_set"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"
@@ -31,7 +31,6 @@ itertools = ">=0.8"
 lz4 = "*"
 fastq = "^0.6"
 bio = "0.33.0"
-generic-array = "0.14.4"
 
 [dev-dependencies]
 time = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,10 @@ pretty_assertions = "0.6.1"
 name = "benchmarks"
 harness = false
 
+[[bench]]
+name = "array_bench"
+harness = false
+
 [dev-dependencies.proptest]
 version = "0.10"
 default-features = false

--- a/benches/array_bench.rs
+++ b/benches/array_bench.rs
@@ -1,0 +1,23 @@
+#[macro_use]
+extern crate criterion;
+use criterion::Criterion;
+use fastq_set::SSeq;
+
+fn run_benchmark(c: &mut Criterion) {
+    c.bench(
+        "bench-byte-array",
+        criterion::Benchmark::new("from-bytes", |b| {
+            b.iter(|| SSeq::from_bytes(b"AGTCCTCTGCATTTTG"))
+        })
+        .with_function("from-bytes-unchecked", |b| {
+            b.iter(|| SSeq::from_bytes_unchecked(b"AGTCCTCTGCATTTTG"))
+        })
+        .with_function("from-iter", |b| {
+            b.iter(|| SSeq::from_iter(b"AGTCCTCTGCATTTTG"))
+        }),
+    );
+}
+
+criterion_group!(benches, run_benchmark);
+
+criterion_main!(benches);

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -214,13 +214,13 @@ fn sseq_serde_bincode(c: &mut Criterion) {
         let seq = b"AGCTAGTCAGTCAGTA";
         let mut sseqs = Vec::new();
         for _i in 0..10_000 {
-            let s = fastq_set::sseq::SSeq::new(seq);
+            let s = fastq_set::sseq::SSeq::from_bytes(seq);
             sseqs.push(s);
         }
 
         b.iter(|| {
             let mut b = Vec::new();
-            bincode::serialize_into(&mut b, &sseqs);
+            bincode::serialize_into(&mut b, &sseqs).unwrap();
             assert!(b.len() > 0);
         })
     });

--- a/src/array.rs
+++ b/src/array.rs
@@ -32,7 +32,20 @@ where
     /// The byte slice should contain only valid alphabets as defined by ArrayContent trait
     /// otherwise this function will panic
     pub fn new(src: &[u8]) -> Self {
-        Self::from_iter(src)
+        assert!(
+            src.len() <= N,
+            "Input slice has length {} which exceeds the capacity of {} bytes in the ByteArray",
+            src.len(),
+            N
+        );
+        T::validate_bytes(src);
+        let mut bytes = [0; N];
+        bytes[0..src.len()].copy_from_slice(&src);
+        ByteArray {
+            length: src.len() as u8,
+            bytes,
+            phantom: PhantomData,
+        }
     }
 
     pub fn from_iter<'a, C, D>(src: D) -> Self

--- a/src/array.rs
+++ b/src/array.rs
@@ -28,6 +28,21 @@ impl<T, const N: usize> ByteArray<T, N>
 where
     T: ArrayContent,
 {
+    pub fn empty() -> Self {
+        ByteArray {
+            length: 0,
+            bytes: [0; N],
+            phantom: PhantomData,
+        }
+    }
+
+    pub fn push(&mut self, src: &[u8]) {
+        let len = self.length as usize;
+        assert!(src.len() <= (N - len));
+        T::validate_bytes(src);
+        self.bytes[len..len + src.len()].copy_from_slice(&src);
+        self.length += src.len() as u8;
+    }
     /// Create a new ByteArray from the given byte slice
     /// The byte slice should contain only valid alphabets as defined by ArrayContent trait
     /// otherwise this function will panic

--- a/src/background_iterator.rs
+++ b/src/background_iterator.rs
@@ -24,7 +24,7 @@ impl<T> BackgroundIterator<T> {
                         None => "unknown panic on BackgroundIterator worker thread".to_string(),
                     },
                 };
-                panic!(msg);
+                panic!("{}", msg);
             }
         }
     }

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -33,7 +33,7 @@ impl From<&str> for SampleIndexSpec {
         SampleIndexSpec::Sequences {
             indices: [index]
                 .iter()
-                .map(|ind| SSeq::new(ind.as_bytes()))
+                .map(|ind| SSeq::from_bytes(ind.as_bytes()))
                 .collect(),
             max_n: 1,
         }

--- a/src/squality.rs
+++ b/src/squality.rs
@@ -2,7 +2,7 @@
 
 //! Sized, stack-allocated container for a short quality string.
 
-use crate::array::{typenum, ArrayContent, ByteArray};
+use crate::array::{ArrayContent, ByteArray};
 use std::iter::Iterator;
 use std::str;
 
@@ -31,12 +31,12 @@ impl ArrayContent for SQualityContents {
 /// Fixed-sized container for a short quality string, with capacity determined by the type `N`.
 /// Used as a convenient container for a barcode or UMI quality string.
 /// An `SQualityGen` is guaranteed to contain only valid quality characters.
-pub type SQualityGen<N> = ByteArray<N, SQualityContents>;
+pub type SQualityGen<const N: usize> = ByteArray<SQualityContents, N>;
 
 /// Fixed-sized container for a short quality string, up to 23bp in length.
 /// Used as a convenient container for a barcode or UMI quality string.
 /// An `SQuality` is guaranteed to contain only valid quality characters.
-pub type SQuality = SQualityGen<typenum::U23>;
+pub type SQuality = SQualityGen<23>;
 
 #[cfg(test)]
 mod squality_test {

--- a/src/squality.rs
+++ b/src/squality.rs
@@ -48,10 +48,10 @@ mod squality_test {
 
     #[test]
     fn test_sseq_valid_quality() {
-        assert_eq!(SQuality::new(&VALID_CHARS[0..23]).len(), 23);
-        assert_eq!(SQuality::new(&VALID_CHARS[23..42]).len(), 19);
+        assert_eq!(SQuality::from_bytes(&VALID_CHARS[0..23]).len(), 23);
+        assert_eq!(SQuality::from_bytes(&VALID_CHARS[23..42]).len(), 19);
         assert_eq!(
-            SQuality::new(&VALID_CHARS[0..23]).to_string(),
+            SQuality::from_bytes(&VALID_CHARS[0..23]).to_string(),
             str::from_utf8(&VALID_CHARS[0..23]).unwrap()
         );
     }
@@ -59,20 +59,20 @@ mod squality_test {
     #[test]
     #[should_panic]
     fn test_sseq_invalid_quality_1() {
-        let _ = SQuality::new(b"GHIJ ");
+        let _ = SQuality::from_bytes(b"GHIJ ");
     }
 
     #[test]
     #[should_panic]
     fn test_sseq_invalid_quality_2() {
-        let _ = SQuality::new(b"GHIJK");
+        let _ = SQuality::from_bytes(b"GHIJK");
     }
 
     #[test]
     fn test_serde() {
         let mut sseqs = Vec::new();
-        sseqs.push(SQuality::new(&VALID_CHARS[0..23]));
-        sseqs.push(SQuality::new(&VALID_CHARS[23..41]));
+        sseqs.push(SQuality::from_bytes(&VALID_CHARS[0..23]));
+        sseqs.push(SQuality::from_bytes(&VALID_CHARS[23..41]));
 
         let mut buf = Vec::new();
         bincode::serialize_into(&mut buf, &sseqs).unwrap();
@@ -85,7 +85,7 @@ mod squality_test {
         fn prop_test_serde_squality(
             ref seq in "[!FGHIJ]{0, 23}",
         ) {
-            let target = SQuality::new(seq.as_bytes());
+            let target = SQuality::from_bytes(seq.as_bytes());
             let encoded: Vec<u8> = bincode::serialize(&target).unwrap();
             let decoded: SQuality = bincode::deserialize(&encoded[..]).unwrap();
             prop_assert_eq!(target, decoded);

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -183,7 +183,7 @@ mod sseq_test {
         let s8 = b"GAACNAGNTGGA";
 
         let mut seqs = vec![s1, s2, s3, s4, s5, s6, s7, s8];
-        let mut sseqs: Vec<SSeq> = seqs.iter().map(|x| SSeq::new(x)).collect();
+        let mut sseqs: Vec<SSeq> = seqs.iter().map(|x| SSeq::from_bytes(x)).collect();
 
         seqs.sort();
         sseqs.sort();
@@ -199,7 +199,7 @@ mod sseq_test {
             ref seqs_str in vec("[ACGTN]{0, 23}", 0usize..=10usize),
         ) {
             let mut seqs = seqs_str.iter().map(|s| s.clone().into_bytes()).collect_vec();
-            let mut sseqs: Vec<SSeq> = seqs.iter().map(|x| SSeq::new(x)).collect();
+            let mut sseqs: Vec<SSeq> = seqs.iter().map(|x| SSeq::from_bytes(x)).collect();
 
             seqs.sort();
             sseqs.sort();
@@ -212,19 +212,19 @@ mod sseq_test {
 
     #[test]
     fn dna_encode() {
-        let s1 = SSeq::new(b"AAAAA");
+        let s1 = SSeq::from_bytes(b"AAAAA");
         assert_eq!(s1.encode_2bit_u32(), 0);
 
-        let s1 = SSeq::new(b"AAAAT");
+        let s1 = SSeq::from_bytes(b"AAAAT");
         assert_eq!(s1.encode_2bit_u32(), 3);
 
-        let s1 = SSeq::new(b"AAACA");
+        let s1 = SSeq::from_bytes(b"AAACA");
         assert_eq!(s1.encode_2bit_u32(), 4);
 
-        let s1 = SSeq::new(b"AACAA");
+        let s1 = SSeq::from_bytes(b"AACAA");
         assert_eq!(s1.encode_2bit_u32(), 16);
 
-        let s1 = SSeq::new(b"AATA");
+        let s1 = SSeq::from_bytes(b"AATA");
         assert_eq!(s1.encode_2bit_u32(), 12);
     }
 
@@ -233,7 +233,7 @@ mod sseq_test {
         let seq = b"AGCTAGTCAGTCAGTA";
         let mut sseqs = Vec::new();
         for _ in 0..4 {
-            let s = SSeq::new(seq);
+            let s = SSeq::from_bytes(seq);
             sseqs.push(s);
         }
 
@@ -245,7 +245,7 @@ mod sseq_test {
 
     #[test]
     fn test_serde_json() {
-        let seq = SSeq::new(b"AGCTAGTCAGTCAGTA");
+        let seq = SSeq::from_bytes(b"AGCTAGTCAGTCAGTA");
         let json_str = serde_json::to_string(&seq).unwrap();
         assert_eq!(json_str, r#""AGCTAGTCAGTCAGTA""#);
     }
@@ -255,7 +255,7 @@ mod sseq_test {
         fn prop_test_serde_sseq(
             ref seq in "[ACGTN]{0, 23}",
         ) {
-            let target = SSeq::new(seq.as_bytes());
+            let target = SSeq::from_bytes(seq.as_bytes());
             let encoded: Vec<u8> = bincode::serialize(&target).unwrap();
             let decoded: SSeq = bincode::deserialize(&encoded[..]).unwrap();
             prop_assert_eq!(target, decoded);
@@ -264,7 +264,7 @@ mod sseq_test {
         fn prop_test_serde_json_sseq(
             ref seq in "[ACGTN]{0, 23}",
         ) {
-            let target = SSeq::new(seq.as_bytes());
+            let target = SSeq::from_bytes(seq.as_bytes());
             let encoded = serde_json::to_string_pretty(&target).unwrap();
             let decoded: SSeq = serde_json::from_str(&encoded).unwrap();
             prop_assert_eq!(target, decoded);
@@ -276,7 +276,7 @@ mod sseq_test {
             ref seq2 in "[ACGTN]{0, 23}",
         ) {
             if seq1.len() + seq2.len() <= 23 {
-                let mut s = SSeq::empty();
+                let mut s = SSeq::new();
                 s.push(seq1.as_bytes());
                 s.push(seq2.as_bytes());
                 assert_eq!(s, SSeq::from_iter(seq1.as_bytes().iter().chain(seq2.as_bytes().iter())));
@@ -285,7 +285,7 @@ mod sseq_test {
     }
 
     fn test_hamming_helper(seq: &String, opt: HammingIterOpt, n: u8) {
-        let sseq = SSeq::new(seq.as_bytes());
+        let sseq = SSeq::from_bytes(seq.as_bytes());
         // Make sure that the hamming distance is 1 for all elements
         for neighbor in sseq.one_hamming_iter(opt) {
             assert_eq!(
@@ -322,78 +322,78 @@ mod sseq_test {
     #[test]
     #[should_panic]
     fn test_sseq_invalid_1() {
-        let _ = SSeq::new(b"ASDF");
+        let _ = SSeq::from_bytes(b"ASDF");
     }
 
     #[test]
     #[should_panic]
     fn test_sseq_invalid_2() {
-        let _ = SSeq::new(b"ag");
+        let _ = SSeq::from_bytes(b"ag");
     }
 
     #[test]
     #[should_panic]
     fn test_sseq_too_long() {
-        let _ = SSeq::new(b"GGGACCGTCGGTAAAGCTACAGTGAGGGATGTAGTGATGC");
+        let _ = SSeq::from_bytes(b"GGGACCGTCGGTAAAGCTACAGTGAGGGATGTAGTGATGC");
     }
 
     #[test]
     fn test_as_bytes() {
-        assert_eq!(SSeq::new(b"ACGT").as_bytes(), b"ACGT");
+        assert_eq!(SSeq::from_bytes(b"ACGT").as_bytes(), b"ACGT");
     }
 
     #[test]
     fn test_has_n() {
-        assert!(SSeq::new(b"ACGTN").has_n());
-        assert!(!SSeq::new(b"ACGT").has_n());
+        assert!(SSeq::from_bytes(b"ACGTN").has_n());
+        assert!(!SSeq::from_bytes(b"ACGT").has_n());
     }
 
     #[test]
     fn test_is_homopolymer() {
-        assert!(SSeq::new(b"AAAA").is_homopolymer());
-        assert!(!SSeq::new(b"ACGT").is_homopolymer());
+        assert!(SSeq::from_bytes(b"AAAA").is_homopolymer());
+        assert!(!SSeq::from_bytes(b"ACGT").is_homopolymer());
     }
 
     #[test]
     fn test_has_homopolymer_suffix() {
-        assert!(SSeq::new(b"ACGTAAAAA").has_homopolymer_suffix(b'A', 5));
-        assert!(!SSeq::new(b"ACGTTAAAA").has_homopolymer_suffix(b'A', 5));
-        assert!(SSeq::new(b"CCCCC").has_homopolymer_suffix(b'C', 5));
-        assert!(!SSeq::new(b"GGGG").has_homopolymer_suffix(b'G', 5));
+        assert!(SSeq::from_bytes(b"ACGTAAAAA").has_homopolymer_suffix(b'A', 5));
+        assert!(!SSeq::from_bytes(b"ACGTTAAAA").has_homopolymer_suffix(b'A', 5));
+        assert!(SSeq::from_bytes(b"CCCCC").has_homopolymer_suffix(b'C', 5));
+        assert!(!SSeq::from_bytes(b"GGGG").has_homopolymer_suffix(b'G', 5));
     }
 
     #[test]
     fn test_has_polyt_suffix() {
-        assert!(SSeq::new(b"CGCGTTTTT").has_polyt_suffix(5));
-        assert!(!SSeq::new(b"CGCGAAAAA").has_polyt_suffix(5));
+        assert!(SSeq::from_bytes(b"CGCGTTTTT").has_polyt_suffix(5));
+        assert!(!SSeq::from_bytes(b"CGCGAAAAA").has_polyt_suffix(5));
     }
 
     #[test]
     fn test_one_hamming_simple() {
         assert_equal(
-            SSeq::new(b"GAT")
+            SSeq::from_bytes(b"GAT")
                 .one_hamming_iter(HammingIterOpt::SkipNBase)
                 .collect_vec(),
             vec![
                 b"AAT", b"CAT", b"TAT", b"GCT", b"GGT", b"GTT", b"GAA", b"GAC", b"GAG",
             ]
             .into_iter()
-            .map(|x| SSeq::new(x)),
+            .map(|x| SSeq::from_bytes(x)),
         );
 
         assert_equal(
-            SSeq::new(b"GNT")
+            SSeq::from_bytes(b"GNT")
                 .one_hamming_iter(HammingIterOpt::SkipNBase)
                 .collect_vec(),
             vec![b"ANT", b"CNT", b"TNT", b"GNA", b"GNC", b"GNG"]
                 .into_iter()
-                .map(|x| SSeq::new(x)),
+                .map(|x| SSeq::from_bytes(x)),
         );
     }
 
     #[test]
     fn test_from_iter() {
-        let seq = SSeq::new(b"ACGT");
+        let seq = SSeq::from_bytes(b"ACGT");
         let _ = SSeq::from_iter(seq.as_bytes());
         let seq_vec = seq.as_bytes().to_vec();
         let _ = SSeq::from_iter(seq_vec.into_iter());

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -2,8 +2,7 @@
 
 //! Sized, stack-allocated container for a short DNA sequence.
 
-use crate::array::{typenum, ArrayContent, ByteArray};
-use generic_array::ArrayLength;
+use crate::array::{ArrayContent, ByteArray};
 use std::iter::Iterator;
 use std::str;
 
@@ -33,18 +32,14 @@ impl ArrayContent for SSeqContents {
 /// Fixed-sized container for a short DNA sequence, with capacity determined by type `N`.
 /// Used as a convenient container for barcode or UMI sequences.
 /// An `SSeqGen` is guaranteed to contain only "ACGTN" alphabets
-pub type SSeqGen<N> = ByteArray<N, SSeqContents>;
+pub type SSeqGen<const N: usize> = ByteArray<SSeqContents, N>;
 
 /// Fixed-sized container for a short DNA sequence, up to 23bp in length.
 /// Used as a convenient container for barcode or UMI sequences.
 /// An `SSeq` is guaranteed to contain only "ACGTN" alphabets
-pub type SSeq = SSeqGen<typenum::U23>;
+pub type SSeq = SSeqGen<23>;
 
-impl<N> SSeqGen<N>
-where
-    N: ArrayLength<u8>,
-    N::ArrayType: Copy,
-{
+impl<const N: usize> SSeqGen<N> {
     /// Returns a byte slice of this sequence's contents.
     /// A synonym for as_bytes().
     pub fn seq(&self) -> &[u8] {
@@ -116,11 +111,7 @@ pub enum HammingIterOpt {
 /// from an `SSeq`. `SSeq` is guaranteed to contain "ACGTN" alphabets.
 /// Positions containing "N" or "n" are mutated or skipped
 /// depending on the `HammingIterOpt`
-pub struct SSeqOneHammingIter<N>
-where
-    N: ArrayLength<u8>,
-    N::ArrayType: Copy,
-{
+pub struct SSeqOneHammingIter<const N: usize> {
     source: SSeqGen<N>,      // Original SSeq from which we need to generate values
     chars: &'static [u8; 5], // Whether it's ACGTN or acgtn
     position: usize,         // Index into SSeq where last base was mutated
@@ -128,11 +119,7 @@ where
     skip_n: bool,            // Whether to skip N bases or mutate them
 }
 
-impl<N> SSeqOneHammingIter<N>
-where
-    N: ArrayLength<u8>,
-    N::ArrayType: Copy,
-{
+impl<const N: usize> SSeqOneHammingIter<N> {
     fn new(sseq: SSeqGen<N>, opt: HammingIterOpt) -> Self {
         let chars = UPPER_ACGTN;
         SSeqOneHammingIter {
@@ -148,11 +135,7 @@ where
     }
 }
 
-impl<N> Iterator for SSeqOneHammingIter<N>
-where
-    N: ArrayLength<u8>,
-    N::ArrayType: Copy,
-{
+impl<const N: usize> Iterator for SSeqOneHammingIter<N> {
     type Item = SSeqGen<N>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -269,6 +269,19 @@ mod sseq_test {
             let decoded: SSeq = serde_json::from_str(&encoded).unwrap();
             prop_assert_eq!(target, decoded);
         }
+
+        #[test]
+        fn prop_test_sseq_push(
+            ref seq1 in "[ACGTN]{0, 23}",
+            ref seq2 in "[ACGTN]{0, 23}",
+        ) {
+            if seq1.len() + seq2.len() <= 23 {
+                let mut s = SSeq::empty();
+                s.push(seq1.as_bytes());
+                s.push(seq2.as_bytes());
+                assert_eq!(s, SSeq::from_iter(seq1.as_bytes().iter().chain(seq2.as_bytes().iter())));
+            }
+        }
     }
 
     fn test_hamming_helper(seq: &String, opt: HammingIterOpt, n: u8) {


### PR DESCRIPTION
Moving to const generics is a breaking change. There are breaking changes to the API as well:

- Introduce `_unchecked` fn versions which do not perform validation
- `new()` creates an empty `ByteArray` and you can `push()` slices. Useful for multi-part sequences
- Criterion timing:
```
bench-byte-array/from-bytes                                                                             
                        time:   [17.308 ns 17.478 ns 17.662 ns]

bench-byte-array/from-bytes-unchecked                                                                             
                        time:   [2.7468 ns 2.7605 ns 2.7756 ns]

bench-byte-array/from-iter                                                                             
                        time:   [21.335 ns 21.450 ns 21.574 ns]
```