### PR TITLE
Replace `failure` with `anyhow`/`thiserror`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,9 @@ name = "anyhow"
 version = "1.0.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61604a8f862e1d5c3229fdd78f8b02c68dcf73a4c4b05fd636d12240aaa242c1"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "approx"
@@ -454,28 +457,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "failure"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d32e9bd16cc02eae7db7ef620b392808b89f6a5e16bb3497d159c6b92a0f4f86"
-dependencies = [
- "backtrace",
- "failure_derive",
-]
-
-[[package]]
-name = "failure_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa4da3c766cd7a0db8242e326e9e4e081edd567072893ed320008189715366a4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "synstructure",
-]
-
-[[package]]
 name = "fastq"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -490,11 +471,11 @@ dependencies = [
 name = "fastq_set"
 version = "0.5.0"
 dependencies = [
+ "anyhow",
  "bincode",
  "bio",
  "bytes",
  "criterion",
- "failure",
  "fastq",
  "file_diff",
  "flate2",
@@ -512,6 +493,7 @@ dependencies = [
  "serde",
  "serde_derive",
  "serde_json",
+ "thiserror",
 ]
 
 [[package]]
@@ -1390,18 +1372,6 @@ checksum = "c6f107db402c2c2055242dbf4d2af0e69197202e9faacbef9571bbe47f5a1b84"
 dependencies = [
  "proc-macro2",
  "quote",
- "unicode-xid",
-]
-
-[[package]]
-name = "synstructure"
-version = "0.12.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "474aaa926faa1603c40b7885a9eaea29b444d1cb2850cb7c0e37bb1a4182f4fa"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
  "unicode-xid",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ flate2 = { version = "^1.0", features = ["zlib"], default-features = false }
 serde_derive = "*"
 serde = "*"
 bytes = { version = ">=0.5, <2", features = ["serde"] }
-failure = { version = "0.1", features = ["backtrace"] }
+anyhow = { version = "1", features = ["backtrace"] }
 regex = { version = "1", default-features = false, features = ["std", "perf"] }
 lazy_static = "1"
 rand = ">=0.7, <2"
@@ -27,6 +27,7 @@ itertools = ">=0.8"
 lz4 = "*"
 fastq = "^0.6"
 bio = ">=0.33.0, <2"
+thiserror = "1"
 
 [dev-dependencies]
 file_diff = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fastq_set"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Patrick Marks <patrick@10xgenomics.com>", "Sreenath Krishnan <sreenath.krishnan@10xgenomics.com>"]
 edition = "2018"
 license = "MIT"

--- a/examples/trim.rs
+++ b/examples/trim.rs
@@ -1,6 +1,6 @@
 use fastq_set::adapter_trimmer::{Adapter, AdapterTrimmer};
 
-use failure::Error;
+use anyhow::Error;
 
 #[macro_use]
 extern crate serde_derive;

--- a/src/filenames/bcl2fastq.rs
+++ b/src/filenames/bcl2fastq.rs
@@ -4,7 +4,7 @@ use super::FindFastqs;
 use crate::filenames::LaneMode;
 use crate::filenames::LaneSpec;
 use crate::read_pair_iter::InputFastqs;
-use failure::Error;
+use anyhow::Error;
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -6,7 +6,7 @@ use crate::filenames::LaneSpec;
 use crate::read_pair_iter::InputFastqs;
 use crate::sample_index_map::SAMPLE_INDEX_MAP;
 use crate::sseq::SSeq;
-use failure::Error;
+use anyhow::Error;
 use itertools::Itertools;
 use regex;
 use serde::{Deserialize, Serialize};

--- a/src/filenames/fastq_dir.rs
+++ b/src/filenames/fastq_dir.rs
@@ -5,7 +5,7 @@ use crate::filenames::bcl_processor::{self, BclProcessorFileGroup};
 use crate::filenames::{LaneMode, LaneSpec};
 use crate::read_pair_iter::InputFastqs;
 use crate::sample_index_map::SAMPLE_INDEX_MAP;
-use failure::{format_err, Error, ResultExt};
+use anyhow::{format_err, Error};
 use itertools::Itertools;
 use std::collections::HashSet;
 use std::path::Path;
@@ -179,12 +179,13 @@ impl FastqChecker {
         lanes: &Option<Vec<usize>>,
         help_text: &str,
     ) -> Result<HashSet<String>, Error> {
-        let bcl_dir = Bcl2FastqDir::new(&fastq_path).with_context(|e| {
-            format!(
+        let bcl_dir = Bcl2FastqDir::new(&fastq_path).map_err(|e| {
+            let context = format!(
                 "Error reading fastq directory {:?} due to:\n{}",
                 fastq_path.as_ref(),
                 e
-            )
+            );
+            e.context(context)
         })?;
 
         if bcl_dir.is_empty() {

--- a/src/filenames/mod.rs
+++ b/src/filenames/mod.rs
@@ -5,11 +5,11 @@ pub mod bcl_processor;
 pub mod fastq_dir;
 
 use crate::read_pair_iter::InputFastqs;
+use anyhow::Error;
 pub use bcl2fastq::Bcl2FastqDef;
 use bcl2fastq::SampleNameSpec;
 pub use bcl_processor::BclProcessorFastqDef;
 use bcl_processor::SampleIndexSpec;
-use failure::Error;
 use serde::{Deserialize, Serialize};
 
 use std::collections::HashSet;

--- a/src/illumina_header_info.rs
+++ b/src/illumina_header_info.rs
@@ -1,4 +1,4 @@
-use failure::{format_err, Error};
+use anyhow::{format_err, Error};
 use serde::{Deserialize, Serialize};
 
 use crate::read_pair::{ReadPart, WhichRead};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ pub mod utils;
 use crate::read_pair_iter::{AnyReadPairIter, InputFastqs, ReadPairIter};
 pub use crate::squality::SQuality;
 pub use crate::sseq::SSeq;
-use failure::Error;
+use anyhow::Error;
 pub use fastq::OwnedRecord;
 pub use fastq::Record;
 pub use read_pair::WhichRead;

--- a/src/read_pair.rs
+++ b/src/read_pair.rs
@@ -4,8 +4,8 @@
 //! including the primary 'R1' and 'R2' and index 'I1' and 'I2' reads.
 
 use crate::WhichEnd;
+use anyhow::{format_err, Error};
 use bytes::{Bytes, BytesMut};
-use failure::{format_err, Error};
 use fastq::{OwnedRecord, Record};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/src/read_pair_writer.rs
+++ b/src/read_pair_writer.rs
@@ -1,6 +1,6 @@
 //! Write `ReadPair` objects to a set of FASTQ files.
 
-use failure::{Error, ResultExt};
+use anyhow::{Context, Error};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
@@ -69,12 +69,12 @@ impl ReadPairWriter {
             if let Some(ref mut writer) = *writer_opt {
                 let which = WhichRead::read_types()[idx];
 
-                rec.write_fastq(which, writer).with_context(|_| {
+                rec.write_fastq(which, writer).with_context(|| {
                     format!("error writing fastq record to file: {:?}", paths[idx])
                 })?;
 
                 if which == WhichRead::R1 && self.r1_interleaved {
-                    rec.write_fastq(WhichRead::R2, writer).with_context(|_| {
+                    rec.write_fastq(WhichRead::R2, writer).with_context(|| {
                         format!("error writing fastq record to file: {:?}", paths[idx])
                     })?;
                 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -7,7 +7,7 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::path::Path;
 
-use failure::Error;
+use anyhow::Error;
 use flate2::write::GzEncoder;
 
 const GZ_BUF_SIZE: usize = 1 << 22;


### PR DESCRIPTION
`failure` is [deprecated](https://github.com/rust-lang-deprecated/failure#failure---a-new-error-management-story). `anyhow` is a recommended replacement for `failure::Error`, including backtraces (with the `backtrace` feature).

## Details

`read_pair_iter::FastqError` is not a `failure::Fail` anymore, it is an `std::error::Error` derived with `thiserror`. I had to remove the `backtrace` field because `thiserror` is based on `std::backtrace`, which is [not stable yet](https://github.com/dtolnay/thiserror#details). This is compensated by `anyhow::Error` being used in public interfaces, which [guarantees a backtrace is available](https://docs.rs/anyhow/1.0.44/anyhow/struct.Error.html#).

## TODO

- [x] version bump (minor or patch?)