### PR TITLE
Various cleanups and fixes.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: weekly
+  allow:
+    - dependency-type: "direct"
+  open-pull-requests-limit: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,7 @@ jobs:
             -W rust_2018_compatibility
             -W rust_2021_compatibility
             -W unused
+      - uses: EmbarkStudios/cargo-deny-action@v1      
       - name: Build
         run: cargo build --release
       - name: Unit tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1026,18 +1026,15 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0d9cc07f18492d879586c92b485def06bc850da3118075cd45d50e9c95b0e5"
 dependencies = [
- "bit-set",
  "bitflags",
  "byteorder",
  "lazy_static",
  "num-traits",
- "quick-error 2.0.1",
+ "quick-error",
  "rand",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
- "rusty-fork",
- "tempfile",
 ]
 
 [[package]]
@@ -1058,12 +1055,6 @@ dependencies = [
  "thiserror",
  "unescape",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-error"
@@ -1171,15 +1162,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.2.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1203,15 +1185,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
-name = "remove_dir_all"
-version = "0.5.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "rustc-demangle"
 version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1233,18 +1206,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
 dependencies = [
  "semver 1.0.4",
-]
-
-[[package]]
-name = "rusty-fork"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb3dcc6e454c328bb824492db107ab7c0ae8fcffe4ad210136ef014458c1bc4f"
-dependencies = [
- "fnv",
- "quick-error 1.2.3",
- "tempfile",
- "wait-timeout",
 ]
 
 [[package]]
@@ -1376,20 +1337,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tempfile"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dac1c663cfc93810f88aed9b8941d48cabf856a1b111c29a40439018d870eb22"
-dependencies = [
- "cfg-if 1.0.0",
- "libc",
- "rand",
- "redox_syscall",
- "remove_dir_all",
- "winapi",
-]
-
-[[package]]
 name = "textwrap"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1490,15 +1437,6 @@ name = "void"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
-name = "wait-timeout"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f200f5b12eb75f8c1ed65abd4b2db8a6e1b138a20de009dacee265a2498f3f6"
-dependencies = [
- "libc",
-]
 
 [[package]]
 name = "walkdir"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,7 +78,7 @@ checksum = "e7a905d892734eea339e896738c14b9afce22b5318f64b951e70bf3844419b01"
 dependencies = [
  "addr2line",
  "cc",
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "miniz_oxide",
  "object",
@@ -234,12 +234,6 @@ checksum = "d26a6ce4b6a484fa3edb70f7efa6fc430fd2b87285fe8b84304fd0936faa0dc0"
 
 [[package]]
 name = "cfg-if"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
-
-[[package]]
-name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
@@ -261,7 +255,7 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81156fece84ab6a9f2afdb109ce3ae577e42b1228441eded99bd77f627953b1a"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -306,7 +300,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ed27e177f16d65f0f0c22a213e17c696ace5dd64b14258b52f9417ccb52db4"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
 ]
 
@@ -316,7 +310,7 @@ version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6455c0ca19f0d2fbf751b908d5c55c1f5cbc65e03c4225427254b46890bdde1e"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-epoch",
  "crossbeam-utils",
 ]
@@ -327,7 +321,7 @@ version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec02e091aa634e2c3ada4a392989e7c3116673ef0ac5b72232439094d73b7fd"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crossbeam-utils",
  "lazy_static",
  "memoffset",
@@ -340,7 +334,7 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d82cfc11ce7f2c3faef78d8a684447b40d503d9681acebed6cb728d45940c4db"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "lazy_static",
 ]
 
@@ -383,41 +377,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
 
 [[package]]
-name = "darwin-libproc"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb90051930c9a0f09e585762152048e23ac74d20c10590ef7cf01c0343c3046"
-dependencies = [
- "darwin-libproc-sys",
- "libc",
- "memchr",
-]
-
-[[package]]
-name = "darwin-libproc-sys"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cebb5bde66eecdd30ddc4b9cd208238b15db4982ccc72db59d699ea10867c1"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "derive-new"
 version = "0.5.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_more"
-version = "0.99.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40eebddd2156ce1bb37b20bbe5151340a31828b1f2d22ba4141f3531710e38df"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -482,11 +445,11 @@ dependencies = [
  "glob",
  "itertools",
  "lazy_static",
+ "libc",
  "lz4",
  "ordered-float",
  "pretty_assertions",
  "proptest",
- "psutil",
  "rand",
  "rand_xorshift",
  "regex",
@@ -520,7 +483,7 @@ version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "crc32fast",
  "libc",
  "libz-sys",
@@ -548,7 +511,7 @@ version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcd999463524c52659517fe2cea98493cfe485d10565e7b0fb07dbba7ad2753"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "libc",
  "wasi",
 ]
@@ -685,7 +648,7 @@ version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
 ]
 
 [[package]]
@@ -705,15 +668,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dca79aa95d8b3226213ad454d328369853be3a1382d89532a854f4d69640acae"
 dependencies = [
  "cc",
- "libc",
-]
-
-[[package]]
-name = "mach"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
-dependencies = [
  "libc",
 ]
 
@@ -812,19 +766,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nix"
-version = "0.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50e4785f2c3b7589a0d0c1dd60285e1188adac4006e8abd6dd578e1567027363"
-dependencies = [
- "bitflags",
- "cc",
- "cfg-if 0.1.10",
- "libc",
- "void",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -884,12 +825,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "692fcb63b64b1758029e0a96ee63e049ce8c5948587f2f7208df04625e5f6b56"
-
-[[package]]
 name = "oorandom"
 version = "11.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,12 +869,6 @@ name = "pkg-config"
 version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3831453b3449ceb48b6d9c7ad7c96d5ea673e9b470a1dc578c2ce6521230884c"
-
-[[package]]
-name = "platforms"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "feb3b2b1033b8a60b4da6ee470325f887758c95d5320f52f9ce0df055a55940e"
 
 [[package]]
 name = "plotters"
@@ -1035,25 +964,6 @@ dependencies = [
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
-]
-
-[[package]]
-name = "psutil"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e780a52bf9358cb8257cac630b130dc603901f7488f8eef13e2d512cead10739"
-dependencies = [
- "cfg-if 0.1.10",
- "darwin-libproc",
- "derive_more",
- "glob",
- "mach",
- "nix",
- "num_cpus",
- "once_cell",
- "platforms",
- "thiserror",
- "unescape",
 ]
 
 [[package]]
@@ -1388,12 +1298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b63708a265f51345575b27fe43f9500ad611579e764c79edbc2037b1121959ec"
 
 [[package]]
-name = "unescape"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccb97dac3243214f8d8507998906ca3e2e0b900bf9bf4870477f125b82e68f6e"
-
-[[package]]
 name = "unicode-segmentation"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1433,12 +1337,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fecdca9a5291cc2b8dcf7dc02453fee791a280f3743cb0905f8822ae463b3fe"
 
 [[package]]
-name = "void"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
-
-[[package]]
 name = "walkdir"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1461,7 +1359,7 @@ version = "0.2.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "632f73e236b219150ea279196e54e610f5dbafa5d61786303d4da54f84e47fce"
 dependencies = [
- "cfg-if 1.0.0",
+ "cfg-if",
  "wasm-bindgen-macro",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ file_diff = "1.0"
 glob = ">=0.3, <2"
 criterion = "0.3"
 bincode = "*"
-psutil = ">=3.0"
+libc = ">=0.2"
 pretty_assertions = "0.7.2"
 serde_json = "*"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ file_diff = "1.0"
 glob = ">=0.3, <2"
 criterion = "0.3"
 bincode = "*"
-psutil = ">=2.0"
+psutil = ">=3.0"
 pretty_assertions = "0.7.2"
 serde_json = "*"
 
@@ -49,5 +49,4 @@ harness = false
 [dev-dependencies.proptest]
 version = "1"
 default-features = false
-# Enable all default features not known to break code coverage builds
-features = ["default-code-coverage"]
+features = ["std"]

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,203 @@
+# This template contains all of the possible sections and their default values
+
+# Note that all fields that take a lint level have these possible values:
+# * deny - An error will be produced and the check will fail
+# * warn - A warning will be produced, but the check will not fail
+# * allow - No warning or error will be produced, though in some cases a note
+# will be
+
+# The values provided in this template are the default values that will be used
+# when any section or field is not specified in your own configuration
+
+# If 1 or more target triples (and optionally, target_features) are specified,
+# only the specified targets will be checked when running `cargo deny check`.
+# This means, if a particular package is only ever used as a target specific
+# dependency, such as, for example, the `nix` crate only being used via the
+# `target_family = "unix"` configuration, that only having windows targets in
+# this list would mean the nix crate, as well as any of its exclusive
+# dependencies not shared by any other crates, would be ignored, as the target
+# list here is effectively saying which targets you are building for.
+targets = [
+    # The triple can be any string, but only the target triples built in to
+    # rustc (as of 1.40) can be checked against actual config expressions
+    { triple = "x86_64-unknown-linux-gnu" },
+    # You can also specify which target_features you promise are enabled for a
+    # particular target. target_features are currently not validated against
+    # the actual valid features supported by the target architecture.
+    #{ triple = "wasm32-unknown-unknown", features = ["atomics"] },
+]
+
+# This section is considered when running `cargo deny check advisories`
+# More documentation for the advisories section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/advisories/cfg.html
+[advisories]
+# The path where the advisory database is cloned/fetched into
+# db-path = "~/.cargo/advisory-db"
+# The url(s) of the advisory databases to use
+db-urls = ["https://github.com/rustsec/advisory-db"]
+# The lint level for security vulnerabilities
+vulnerability = "deny"
+# The lint level for unmaintained crates
+unmaintained = "warn"
+# The lint level for crates that have been yanked from their source registry
+yanked = "warn"
+# The lint level for crates with security notices. Note that as of
+# 2019-12-17 there are no security notice advisories in
+# https://github.com/rustsec/advisory-db
+notice = "warn"
+# A list of advisory IDs to ignore. Note that ignored advisories will still
+# output a note when they are encountered.
+ignore = [
+]
+# Threshold for security vulnerabilities, any vulnerability with a CVSS score
+# lower than the range specified will be ignored. Note that ignored advisories
+# will still output a note when they are encountered.
+# * None - CVSS Score 0.0
+# * Low - CVSS Score 0.1 - 3.9
+# * Medium - CVSS Score 4.0 - 6.9
+# * High - CVSS Score 7.0 - 8.9
+# * Critical - CVSS Score 9.0 - 10.0
+#severity-threshold = 
+
+# This section is considered when running `cargo deny check licenses`
+# More documentation for the licenses section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/licenses/cfg.html
+[licenses]
+# The lint level for crates which do not have a detectable license
+unlicensed = "deny"
+# List of explictly allowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+allow = [
+    "Apache-2.0",
+    "BSD-3-Clause",
+    "MIT",
+]
+# List of explictly disallowed licenses
+# See https://spdx.org/licenses/ for list of possible licenses
+# [possible values: any SPDX 3.11 short identifier (+ optional exception)].
+deny = [
+    #"Nokia",
+]
+# Lint level for licenses considered copyleft
+copyleft = "warn"
+# Blanket approval or denial for OSI-approved or FSF Free/Libre licenses
+# * both - The license will be approved if it is both OSI-approved *AND* FSF
+# * either - The license will be approved if it is either OSI-approved *OR* FSF
+# * osi-only - The license will be approved if is OSI-approved *AND NOT* FSF
+# * fsf-only - The license will be approved if is FSF *AND NOT* OSI-approved
+# * neither - This predicate is ignored and the default lint level is used
+allow-osi-fsf-free = "neither"
+# Lint level used when no other predicates are matched
+# 1. License isn't in the allow or deny lists
+# 2. License isn't copyleft
+# 3. License isn't OSI/FSF, or allow-osi-fsf-free = "neither"
+default = "deny"
+# The confidence threshold for detecting a license from license text.
+# The higher the value, the more closely the license text must be to the
+# canonical license text of a valid SPDX license file.
+# [possible values: any between 0.0 and 1.0].
+confidence-threshold = 0.6
+# Allow 1 or more licenses on a per-crate basis, so that particular licenses
+# aren't accepted for every possible crate as with the normal allow list
+exceptions = [
+    # Each entry is the crate and version constraint, and its specific allow
+    # list
+    #{ allow = ["Zlib"], name = "adler32", version = "*" },
+]
+
+# Some crates don't have (easily) machine readable licensing information,
+# adding a clarification entry for it allows you to manually specify the
+# licensing information
+#[[licenses.clarify]]
+# The name of the crate the clarification applies to
+#name = "ring"
+# The optional version constraint for the crate
+#version = "*"
+# The SPDX expression for the license requirements of the crate
+#expression = "MIT AND ISC AND OpenSSL"
+# One or more files in the crate's source used as the "source of truth" for
+# the license expression. If the contents match, the clarification will be used
+# when running the license check, otherwise the clarification will be ignored
+# and the crate will be checked normally, which may produce warnings or errors
+# depending on the rest of your configuration
+#license-files = [
+    # Each entry is a crate relative path, and the (opaque) hash of its contents
+    #{ path = "LICENSE", hash = 0xbd0eed23 }
+#]
+
+[licenses.private]
+# If true, ignores workspace crates that aren't published, or are only
+# published to private registries
+ignore = true
+# One or more private registries that you might publish crates to, if a crate
+# is only published to private registries, and ignore is true, the crate will
+# not have its license(s) checked
+registries = [
+    #"https://sekretz.com/registry
+]
+
+# This section is considered when running `cargo deny check bans`.
+# More documentation about the 'bans' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/bans/cfg.html
+[bans]
+# Lint level for when multiple versions of the same crate are detected
+multiple-versions = "deny"
+# Lint level for when a crate version requirement is `*`
+wildcards = "allow"
+# The graph highlighting used when creating dotgraphs for crates
+# with multiple versions
+# * lowest-version - The path to the lowest versioned duplicate is highlighted
+# * simplest-path - The path to the version with the fewest edges is highlighted
+# * all - Both lowest-version and simplest-path are used
+highlight = "all"
+# List of crates that are allowed. Use with care!
+allow = [
+    #{ name = "ansi_term", version = "=0.11.0" },
+]
+# List of crates to deny
+deny = [
+    # Each entry the name of a crate and a version range. If version is
+    # not specified, all versions will be matched.
+    #{ name = "ansi_term", version = "=0.11.0" },
+    #
+    # Wrapper crates can optionally be specified to allow the crate when it
+    # is a direct dependency of the otherwise banned crate
+    #{ name = "ansi_term", version = "=0.11.0", wrappers = [] },
+]
+# Certain crates/versions that will be skipped when doing duplicate detection.
+skip = [
+]
+# Similarly to `skip` allows you to skip certain crates during duplicate 
+# detection. Unlike skip, it also includes the entire tree of transitive 
+# dependencies starting at the specified crate, up to a certain depth, which is
+# by default infinite
+skip-tree = [
+     # Requires a lot of changes to dedup
+    { name = "rustc_version" },
+]
+
+# This section is considered when running `cargo deny check sources`.
+# More documentation about the 'sources' section can be found here:
+# https://embarkstudios.github.io/cargo-deny/checks/sources/cfg.html
+[sources]
+# Lint level for what to happen when a crate from a crate registry that is not
+# in the allow list is encountered
+unknown-registry = "warn"
+# Lint level for what to happen when a crate from a git repository that is not
+# in the allow list is encountered
+unknown-git = "warn"
+# List of URLs for allowed crate registries. Defaults to the crates.io index
+# if not specified. If it is specified but empty, no registries are allowed.
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+# List of URLs for allowed Git repositories
+allow-git = [
+]
+
+[sources.allow-org]
+# 1 or more github.com organizations to allow git sources for
+github = ["10XGenomics"]
+# 1 or more gitlab.com organizations to allow git sources for
+gitlab = []
+# 1 or more bitbucket.org organizations to allow git sources for
+bitbucket = []

--- a/src/read_pair.rs
+++ b/src/read_pair.rs
@@ -68,7 +68,7 @@ whichread_from!(usize);
 whichread_from!(u32);
 
 impl WhichRead {
-    pub fn read_types() -> [WhichRead; 4] {
+    pub const fn read_types() -> [WhichRead; 4] {
         [WhichRead::R1, WhichRead::R2, WhichRead::I1, WhichRead::I2]
     }
 }

--- a/src/read_pair_iter.rs
+++ b/src/read_pair_iter.rs
@@ -41,6 +41,7 @@ pub enum FastqError {
 }
 
 impl FastqError {
+    #[cold]
     pub fn format(message: String, path: impl AsRef<Path>, line: usize) -> FastqError {
         FastqError::FastqFormat {
             message,
@@ -51,25 +52,27 @@ impl FastqError {
 }
 
 trait FileIoError<T> {
-    fn open_err(self, path: impl AsRef<Path>) -> Result<T, FastqError>;
-    fn fastq_err(self, path: impl AsRef<Path>, line: usize) -> Result<T, FastqError>;
+    fn open_err(self, path: impl Into<PathBuf>) -> Result<T, FastqError>;
+    fn fastq_err(self, path: impl Into<PathBuf>, line: usize) -> Result<T, FastqError>;
 }
 
 impl<T> FileIoError<T> for Result<T, std::io::Error> {
-    fn open_err(self, path: impl AsRef<Path>) -> Result<T, FastqError> {
+    #[cold]
+    fn open_err(self, path: impl Into<PathBuf>) -> Result<T, FastqError> {
         match self {
             Ok(v) => Ok(v),
             Err(e) => {
                 let e = FastqError::Open {
                     source: e,
-                    file: path.as_ref().to_path_buf(),
+                    file: path.into(),
                 };
                 Err(e)
             }
         }
     }
 
-    fn fastq_err(self, path: impl AsRef<Path>, line: usize) -> Result<T, FastqError> {
+    #[cold]
+    fn fastq_err(self, path: impl Into<PathBuf>, line: usize) -> Result<T, FastqError> {
         match self {
             Ok(v) => Ok(v),
             Err(e) => {
@@ -79,7 +82,7 @@ impl<T> FileIoError<T> for Result<T, std::io::Error> {
                         let e = FastqError::FastqFormat {
                             message: e.to_string(),
                             line,
-                            file: path.as_ref().to_path_buf(),
+                            file: path.into(),
                         };
                         Err(e)
                     }
@@ -88,7 +91,7 @@ impl<T> FileIoError<T> for Result<T, std::io::Error> {
                     _ => {
                         let e = FastqError::Io {
                             source: e,
-                            file: path.as_ref().to_path_buf(),
+                            file: path.into(),
                             line,
                         };
                         Err(e)
@@ -129,7 +132,9 @@ impl InputFastqs {
 
         let mut new_path = new_dir.to_path_buf();
         new_path.push(file_name);
-        new_path.to_string_lossy().to_string()
+        // Panic if the new path is not valid UTF-8-encoded unicode, because
+        // the alternative is to return an incorrect path.
+        new_path.to_str().unwrap().to_string()
     }
 }
 
@@ -159,16 +164,20 @@ impl<'a, R: Record> Record for TrimRecord<'a, R> {
         self.inner.head()
     }
     fn write<W: Write>(&self, writer: &mut W) -> std::io::Result<usize> {
-        let mut written = 0;
         // TODO(lhepler): the fundamental impl in fastq here is busted, write may not write all
         // bytes...
-        written += writer.write(b"@")?;
-        written += writer.write(self.head())?;
-        written += writer.write(b"\n")?;
-        written += writer.write(self.seq())?;
-        written += writer.write(b"\n+\n")?;
-        written += writer.write(self.qual())?;
-        written += writer.write(b"\n")?;
+        const FMT_BYTES: usize = b"@\n\n+\n\n".len();
+        let head = self.head();
+        let seq = self.seq();
+        let qual = self.qual();
+        let written = FMT_BYTES + head.len() + seq.len() + qual.len();
+        writer.write_all(b"@")?;
+        writer.write_all(head)?;
+        writer.write_all(b"\n")?;
+        writer.write_all(seq)?;
+        writer.write_all(b"\n+\n")?;
+        writer.write_all(qual)?;
+        writer.write_all(b"\n")?;
         Ok(written)
     }
 }
@@ -213,12 +222,11 @@ impl ReadPairIter {
     /// Open a FASTQ file that is uncompressed, gzipped compressed, or lz4 compressed.
     /// The extension of the file is ignored & the filetype is determined by looking
     /// for magic bytes at the of the file
-    fn open_fastq(p: impl AsRef<Path>) -> Result<Box<dyn BufRead + Send>, FastqError> {
-        let p = p.as_ref();
-
-        let mut file = std::fs::File::open(p).fastq_err(p, 0)?;
-
-        let mut buf = vec![0u8; 4];
+    fn open_fastq_from_file(
+        p: &Path,
+        mut file: std::fs::File,
+    ) -> Result<Box<dyn BufRead + Send>, FastqError> {
+        let mut buf = [0u8; 4];
         file.read_exact(&mut buf[..]).fastq_err(p, 0)?;
         file.seek(std::io::SeekFrom::Start(0)).fastq_err(p, 0)?;
 
@@ -235,16 +243,22 @@ impl ReadPairIter {
             Ok(Box::new(buf_reader))
         } else {
             let msg =
-            "FASTQ file does not appear to be valid. Input FASTQ file must be gzip or lz4 compressed, or must begin with the '@' symbol".to_string();
+        "FASTQ file does not appear to be valid. Input FASTQ file must be gzip or lz4 compressed, or must begin with the '@' symbol".to_string();
             let e = FastqError::format(msg, p, 0);
             Err(e)
         }
     }
 
     /// Open a (possibly gzip or lz4 compressed) FASTQ file & read some records to confirm the format looks good.
-    fn open_fastq_confirm_fmt(p: impl AsRef<Path>) -> Result<Box<dyn BufRead + Send>, FastqError> {
-        let p = p.as_ref();
-        let reader = Self::open_fastq(p)?;
+    fn open_fastq_confirm_fmt(p: &Path) -> Result<Box<dyn BufRead + Send>, FastqError> {
+        let mut file = std::fs::File::open(p).fastq_err(p, 0)?;
+        // Clone the file descriptor so we can read the file header.
+        // The alternative would be to open the file at that path a second time,
+        // but that would be less performant (because it wouldn't share i/o
+        // cache as effectively, and because it would involve more round trips
+        // to the underlying fileystem) and also technically incorrect
+        // since the file at that path could have changed.
+        let reader = Self::open_fastq_from_file(p, file.try_clone().open_err(p)?)?;
         let parser = fastq::Parser::new(reader);
 
         // make sure we can successfully read some records
@@ -260,7 +274,8 @@ impl ReadPairIter {
         }
 
         // re-open file so we re-read the initial records
-        Self::open_fastq(p)
+        file.seek(std::io::SeekFrom::Start(0)).fastq_err(p, 0)?;
+        Self::open_fastq_from_file(p, file)
     }
 
     /// Open a `ReadPairIter` given of FASTQ files.
@@ -273,15 +288,30 @@ impl ReadPairIter {
         i2: Option<P>,
         r1_interleaved: bool,
     ) -> Result<ReadPairIter, FastqError> {
+        Self::_new(
+            [
+                r1.as_ref().map(P::as_ref),
+                r2.as_ref().map(P::as_ref),
+                i1.as_ref().map(P::as_ref),
+                i2.as_ref().map(P::as_ref),
+            ],
+            r1_interleaved,
+        )
+    }
+
+    fn _new(
+        in_paths: [Option<&Path>; 4],
+        r1_interleaved: bool,
+    ) -> Result<ReadPairIter, FastqError> {
         let mut iters = [None, None, None, None];
         let mut paths = [None, None, None, None];
 
-        for (idx, r) in [r1, r2, i1, i2].iter().enumerate() {
-            if let Some(ref p) = *r {
+        for (idx, r) in IntoIterator::into_iter(in_paths).enumerate() {
+            if let Some(p) = r {
                 let rdr = Self::open_fastq_confirm_fmt(p)?;
                 let parser = fastq::Parser::new(rdr);
                 iters[idx] = Some(parser.ref_iter());
-                paths[idx] = Some(p.as_ref().to_path_buf());
+                paths[idx] = Some(p.to_path_buf());
             }
         }
 
@@ -343,7 +373,10 @@ impl ReadPairIter {
 
         let mut rp = MutReadPair::empty(&mut self.buffer).storage(self.storage);
         loop {
-            let sample = self.uniform.sample(&mut self.rand) < self.subsample_rate;
+            // If we're subsampling, decide whether or not we'll be skipping
+            // this record.
+            let sample = self.subsample_rate >= 1.0
+                || self.uniform.sample(&mut self.rand) < self.subsample_rate;
 
             // Track which reader was the first to finish.
             let mut iter_ended = [false; 4];
@@ -355,10 +388,6 @@ impl ReadPairIter {
 
                     {
                         let record = iter.get();
-                        // track which reader finished
-                        if record.is_none() {
-                            iter_ended[idx] = true;
-                        }
 
                         // Check for non-ACGTN characters
                         if let Some(ref rec) = record {
@@ -372,15 +401,15 @@ impl ReadPairIter {
                                 );
                                 return Err(e);
                             }
-                        }
-
-                        if sample {
-                            let which = WhichRead::read_types()[idx];
-                            let read_length = read_lengths[which as usize];
-                            record.map(|r| {
-                                let tr = TrimRecord::new(&r, read_length);
+                            if sample {
+                                let which = WhichRead::read_types()[idx];
+                                let read_length = read_lengths[which as usize];
+                                let tr = TrimRecord::new(rec, read_length);
                                 rp.push_read(&tr, which)
-                            });
+                            }
+                        } else {
+                            // track which reader finished
+                            iter_ended[idx] = true;
                         }
 
                         rec_num[idx] += 1;
@@ -392,7 +421,26 @@ impl ReadPairIter {
                         iter.advance()
                             .fastq_err(paths[idx].as_ref().unwrap(), (rec_num[idx] + 1) * 4)?;
                         let record = iter.get();
-                        if record.is_none() {
+
+                        // Check for non-ACGTN characters
+                        if let Some(ref rec) = record {
+                            if !fastq::Record::validate_dnan(rec) {
+                                let msg = "FASTQ contains sequence base with character other than [ACGTN].".to_string();
+                                let e = FastqError::format(
+                                    msg,
+                                    paths[idx].as_ref().unwrap(),
+                                    rec_num[idx] * 4,
+                                );
+                                return Err(e);
+                            }
+
+                            if sample {
+                                let which = WhichRead::read_types()[idx + 1];
+                                let read_length = read_lengths[which as usize];
+                                let tr = TrimRecord::new(rec, read_length);
+                                rp.push_read(&tr, which)
+                            }
+                        } else {
                             // We should only hit this if the FASTQ has an odd
                             // number of records. Throw an error
                             let msg = "Input FASTQ file was input as interleaved R1 and R2, but contains an odd number of records".to_string();
@@ -402,28 +450,6 @@ impl ReadPairIter {
                                 rec_num[idx] * 4,
                             );
                             return Err(e);
-                        }
-
-                        // Check for non-ACGTN characters
-                        if let Some(ref rec) = record {
-                            if !fastq::Record::validate_dnan(rec) {
-                                let msg = "FASTQ contains sequence base with character other than [ACGTN].";
-                                let e = FastqError::format(
-                                    msg.to_string(),
-                                    paths[idx].as_ref().unwrap(),
-                                    rec_num[idx] * 4,
-                                );
-                                return Err(e);
-                            }
-                        }
-
-                        if sample {
-                            let which = WhichRead::read_types()[idx + 1];
-                            let read_length = read_lengths[which as usize];
-                            record.map(|r| {
-                                let tr = TrimRecord::new(&r, read_length);
-                                rp.push_read(&tr, which)
-                            });
                         }
 
                         rec_num[idx] += 1;
@@ -464,20 +490,16 @@ impl ReadPairIter {
             }
 
             // At least one of the readers got to the end -- make sure they all did.
-            if iter_ended.iter().any(|x| *x) {
+            if let Some((ended_index, _)) = iter_ended.iter().enumerate().find(|(_, &v)| v) {
                 // Are there any incomplete iterators?
-                let any_not_complete = iter_ended
-                    .iter()
+                let any_not_complete = IntoIterator::into_iter(iter_ended)
                     .zip(paths.iter())
-                    .any(|(ended, path)| path.is_some() && !ended);
+                    .any(|(ended, path)| !ended && path.is_some());
 
                 if any_not_complete {
-                    // Index of a finished iterator
-                    let ended_index = iter_ended.iter().enumerate().find(|(_, v)| **v).unwrap().0;
-
-                    let msg = "Input FASTQ file ended prematurely";
+                    let msg = "Input FASTQ file ended prematurely".to_string();
                     let path = paths[ended_index].as_ref().unwrap();
-                    let e = FastqError::format(msg.to_string(), path, rec_num[ended_index] * 4);
+                    let e = FastqError::format(msg, path, rec_num[ended_index] * 4);
                     return Err(e);
                 } else {
                     return Ok(None);
@@ -496,12 +518,7 @@ impl Iterator for ReadPairIter {
 
     /// Iterate over ReadPair objects
     fn next(&mut self) -> Option<Result<ReadPair, FastqError>> {
-        // Convert Result<Option<_>, Error> to Option<Result<_, Error>>
-        match self.get_next() {
-            Ok(Some(v)) => Some(Ok(v)),
-            Ok(None) => None,
-            Err(v) => Some(Err(v)),
-        }
+        self.get_next().transpose()
     }
 }
 

--- a/src/read_pair_writer.rs
+++ b/src/read_pair_writer.rs
@@ -47,9 +47,9 @@ impl ReadPairWriter {
         let mut writers = [None, None, None, None];
         let mut paths = [None, None, None, None];
 
-        for (idx, r) in [r1, r2, i1, i2].iter().enumerate() {
-            if let Some(ref p) = *r {
-                let wtr = utils::write_with_gz(p)?;
+        for (idx, r) in IntoIterator::into_iter([r1, r2, i1, i2]).enumerate() {
+            if let Some(ref p) = r {
+                let wtr = utils::write_with_gz(p.as_ref())?;
                 writers[idx] = Some(wtr);
                 paths[idx] = Some(p.as_ref().to_path_buf());
             }

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -160,6 +160,14 @@ impl<const N: usize> Iterator for SSeqOneHammingIter<N> {
             Some(next_sseq)
         }
     }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        if self.position >= self.source.len() {
+            (0, Some(0))
+        } else {
+            (0, Some(self.source.len() - self.position))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -13,10 +13,10 @@ use flate2::write::GzEncoder;
 const GZ_BUF_SIZE: usize = 1 << 22;
 
 /// Open a (possibly gzipped) file into a BufReader.
-pub(crate) fn write_with_gz<P: AsRef<Path>>(p: P) -> Result<Box<dyn Write>, Error> {
-    let w = File::create(p.as_ref())?;
+pub(crate) fn write_with_gz(p: &Path) -> Result<Box<dyn Write>, Error> {
+    let w = File::create(p)?;
 
-    let ext = p.as_ref().extension().unwrap();
+    let ext = p.extension().unwrap();
 
     if ext == "gz" {
         let gz = GzEncoder::new(w, flate2::Compression::fast());


### PR DESCRIPTION
Add a dependabot config.

Add a cargo deny check.

Turn off some features of proptest to avoid security advisories.

Get rid of psutil dependency because of security advisories.

Fix a clippy lint for enum varient size difference.

Add a size_hint for SSeqOneHammingIter.

Resolve impl AsRef<Path> to &Path sooner in some cases, to reduce the
amount of generated code from monomorphization.

Use impl Into<PathBuf> instead of impl AsRef<Path> in a few internal
APIs.  It's what was actually required, and in theory could be more
efficient in some cases (which we don't actually encounter).

Mark some error handling code as cold.

Clean up the branching logic in ReadPairIter::get_next to avoid
repeatedly checking record.is_some().

Use into_iter instead of iter in a few cases where we can.

Use map/map_err/transpose in several places where we were using match
expressions.

Use write_all in TrimRecord::write to ensure we don't write incomplete
records.

Make the util module private since there wasn't anything public in it.