### PR TITLE
Handle reads shorter than the requested length

### DIFF
--- a/src/read_pair.rs
+++ b/src/read_pair.rs
@@ -260,12 +260,10 @@ impl RpRange {
             } else {
                 None
             }
+        } else if o < input.len() {
+            Some(&input[o..])
         } else {
-            if o < input.len() {
-                Some(&input[o..])
-            } else {
-                None
-            }
+            None
         }
     }
 

--- a/src/read_pair.rs
+++ b/src/read_pair.rs
@@ -252,10 +252,20 @@ impl RpRange {
     // Slice the input to the range [offset, offset + len).
     fn slice<'a>(&self, input: &'a [u8]) -> Option<&'a [u8]> {
         let o = self.offset();
-        match self.len() {
-            Some(l) if o + l <= input.len() => Some(&input[o..o + l]),
-            None if o <= input.len() => Some(&input[o..]),
-            _ => None,
+        if let Some(l) = self.len() {
+            if o + l < input.len() {
+                Some(&input[o..o + l])
+            } else if o < input.len() {
+                Some(&input[o..])
+            } else {
+                None
+            }
+        } else {
+            if o < input.len() {
+                Some(&input[o..])
+            } else {
+                None
+            }
         }
     }
 

--- a/src/read_pair.rs
+++ b/src/read_pair.rs
@@ -723,11 +723,11 @@ mod tests {
         let r1 = RpRange::new(WhichRead::R1, 0, Some(5));
         assert_eq!(r1.slice(data), Some(&data[..]));
         let r2 = RpRange::new(WhichRead::R1, 0, Some(6));
-        assert_eq!(r2.slice(data), None);
+        assert_eq!(r2.slice(data), Some(&data[..]));
         let r3 = RpRange::new(WhichRead::R1, 0, None);
         assert_eq!(r3.slice(data), Some(&data[..]));
         let r4 = RpRange::new(WhichRead::R1, 5, None);
-        assert_eq!(r4.slice(data), Some(&[][..]));
+        assert_eq!(r4.slice(data), None);
         let r5 = RpRange::new(WhichRead::R1, 6, None);
         assert_eq!(r5.slice(data), None);
     }


### PR DESCRIPTION
Change `RpRange::slice` so that
- `RpRange::new(R2, 0, Some(10)).slice("ACGT")` returns `Some("ACGT")` rather than `None`
- `RpRange::new(R2, 4, None).slice("ACGT")` returns `None` rather than `Some([])`
