### PR TITLE
Increase Max Valid QV Value to 93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,9 +1073,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.5.4"
+version = "1.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+checksum = "1a11647b6b25ff05a515cb92c365cec08801e83423a235b51e231e1808747286"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/src/squality.rs
+++ b/src/squality.rs
@@ -15,7 +15,7 @@ impl ArrayContent for SQualityContents {
     fn validate_bytes(seq: &[u8]) {
         for (i, &c) in seq.iter().enumerate() {
             let q = c as i16 - 33;
-            if !(0..42).contains(&q) {
+            if !(0..94).contains(&q) {
                 panic!(
                     "Invalid quality value {} ASCII character {} at position {}",
                     q, c, i

--- a/src/squality.rs
+++ b/src/squality.rs
@@ -65,7 +65,7 @@ mod squality_test {
     #[test]
     #[should_panic]
     fn test_sseq_invalid_quality_2() {
-        let _ = SQuality::from_bytes(b"GHIJK");
+        let _ = SQuality::from_bytes(b" HIJK");
     }
 
     #[test]


### PR DESCRIPTION
Newer sequencers (e.g. PacB HiFi) can produce QV values up to 93.  Although these QV values are equivalent to absurdly small error rates that likely are not estimated accurately (e.g. QV 92 is an error rate of 6.309573e-10) as the wikipedia article for FASTQ file format states: "Since the maximum observed quality score was previously only 40, various scripts and tools break when they encounter data with quality values larger than 40. For processed reads, scores may be even higher. For example, quality values of 45 are observed in reads from Illumina's Long Read Sequencing Service (previously Moleculo)."

As such, this PR accepts anything up to the maximum allowed value.