### PR TITLE
Fix two clippy issues

### DIFF
--- a/src/adapter_trimmer.rs
+++ b/src/adapter_trimmer.rs
@@ -356,12 +356,12 @@ impl<'a> AdapterTrimmer<'a> {
                         Some(TrimResult {
                             adapter_range: alignment.xstart..alignment.xend,
                             trim_range: match self.adapter.end {
-                                WhichEnd::ThreePrime => (alignment.xstart..alignment.xlen),
-                                WhichEnd::FivePrime => (0..alignment.xend),
+                                WhichEnd::ThreePrime => alignment.xstart..alignment.xlen,
+                                WhichEnd::FivePrime => 0..alignment.xend,
                             },
                             retain_range: match self.adapter.end {
-                                WhichEnd::ThreePrime => (0..alignment.xstart),
-                                WhichEnd::FivePrime => (alignment.xend..alignment.xlen),
+                                WhichEnd::ThreePrime => 0..alignment.xstart,
+                                WhichEnd::FivePrime => alignment.xend..alignment.xlen,
                             },
                             score: alignment.score,
                         })

--- a/src/array.rs
+++ b/src/array.rs
@@ -246,7 +246,7 @@ where
     type IntoIter = std::iter::Take<std::array::IntoIter<u8, N>>;
 
     fn into_iter(self) -> Self::IntoIter {
-        std::array::IntoIter::new(self.bytes).take(self.length as usize)
+        IntoIterator::into_iter(self.bytes).take(self.length as usize)
     }
 }
 


### PR DESCRIPTION
- Fix `ByteArray::into_iter`
- `AdapterTrimmer`: Remove extraneous parentheses
