### PR TITLE
Remove unused dependency on ordered-float.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -440,7 +440,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "lz4",
- "ordered-float",
  "pretty_assertions",
  "proptest",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,6 @@ include = ["src/**/*", "LICENSE.txt", "README.md"]
 resolver = "2"
 
 [dependencies]
-ordered-float = ">=1, <4"
 flate2 = { version = "^1.0", features = ["zlib"], default-features = false }
 serde_derive = "*"
 serde = "*"


### PR DESCRIPTION
The dependency is purely indirect.