### PR TITLE
feat: ignore fastq file groups without the RA read

### DIFF
--- a/src/background_iterator.rs
+++ b/src/background_iterator.rs
@@ -90,7 +90,7 @@ mod test {
     #[test]
     #[should_panic]
     fn panic_bg_iter() {
-        let v = vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+        let v = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
 
         let iter = (0..11usize).map(move |i| {
             if v[i] == 5 {
@@ -110,7 +110,7 @@ mod test {
 
     #[test]
     fn bg_iter() {
-        let v = vec![5; 10];
+        let v = [5; 10];
 
         let iter = (0..10usize).map(move |i| v[i]);
 

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -123,6 +123,10 @@ pub struct BclProcessorFile {
 }
 
 impl BclProcessorFile {
+    /// Create a new `BclProcessorFile` from a full path to a FASTQ file.
+    ///
+    /// Returns `None` if the path is not a file or the filename does not
+    /// match the expected pattern.
     fn new(full_path: &Path) -> Option<Self> {
         let re = "^read-([RI][A0-9])_si-([^_]+)_lane-([0-9]+)-chunk-([0-9]+).fastq(.gz|.lz4)?$";
         let re = regex::Regex::new(re).unwrap();

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -351,12 +351,25 @@ mod tests_from_tenkit {
 
     #[test]
     fn test_ra_missing() -> Result<()> {
+        let path = "tests/filenames/bcl_processor_3";
         let query = BclProcessorFastqDef {
-            fastq_path: "/mnt/analysis/marsoc/pipestances/HLVVHDSX3/BCL_PROCESSOR_PD/HLVVHDSX3/2020.0623.2-0/outs/fastq_path".to_string(),
-            sample_index_spec: "CTCAACCAGG".into(),
+            fastq_path: path.to_string(),
+            sample_index_spec: "ACAGCAAC".into(),
             lane_spec: LaneSpec::Lanes(vec![1, 2].into_iter().collect()),
         };
-        let _ = query.find_fastqs()?;
+        let fastqs = query.find_fastqs()?;
+        let expected = vec![InputFastqs {
+            r1: format!("{path}/read-RA_si-ACAGCAAC_lane-001-chunk-001.fastq.gz"),
+            r2: None,
+            i1: Some(format!(
+                "{path}/read-I1_si-ACAGCAAC_lane-001-chunk-001.fastq.gz"
+            )),
+            i2: Some(format!(
+                "{path}/read-I2_si-ACAGCAAC_lane-001-chunk-001.fastq.gz"
+            )),
+            r1_interleaved: true,
+        }];
+        assert_eq!(fastqs, expected);
 
         Ok(())
     }

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -10,7 +10,6 @@ use itertools::Itertools;
 use regex;
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
-use std::fmt;
 use std::path::{Path, PathBuf};
 
 /// Different ways to specify the sample index for `BclProcessorFastqDef`.
@@ -120,12 +119,28 @@ impl BclProcessorFileGroup {
 pub struct BclProcessorFile {
     pub group: BclProcessorFileGroup,
     pub read: String,
-    pub path: PathBuf,
+    pub full_path: PathBuf,
 }
 
-impl fmt::Display for BclProcessorFile {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}", self.path)
+impl BclProcessorFile {
+    fn new(full_path: &Path) -> Option<Self> {
+        let re = "^read-([RI][A0-9])_si-([^_]+)_lane-([0-9]+)-chunk-([0-9]+).fastq(.gz|.lz4)?$";
+        let re = regex::Regex::new(re).unwrap();
+        full_path.file_name().and_then(|filename| {
+            re.captures(filename.to_str().unwrap())
+                .map(|caps| BclProcessorFile {
+                    full_path: full_path.into(),
+                    read: caps.get(1).unwrap().as_str().to_string(),
+                    group: BclProcessorFileGroup {
+                        si: caps.get(2).unwrap().as_str().to_string(),
+                        lane: caps.get(3).unwrap().as_str().parse().unwrap(),
+                        chunk: caps.get(4).unwrap().as_str().parse().unwrap(),
+                    },
+                })
+        })
+    }
+    fn path_string(&self) -> String {
+        self.full_path.to_str().unwrap().to_string()
     }
 }
 
@@ -174,72 +189,41 @@ pub fn group_samples(
 pub fn find_flowcell_fastqs(
     path: impl AsRef<Path>,
 ) -> Result<Vec<(BclProcessorFileGroup, InputFastqs)>> {
-    let demux_files = get_demux_files(path.as_ref())?
+    Ok(get_demux_files(path.as_ref())?
         .into_iter()
         .sorted()
-        .group_by(|(info, _)| info.group.clone());
-    let flowcell_fastqs = demux_files.into_iter().map(|(group, files)| {
-        let my_files: Vec<_> = files.collect();
+        .group_by(|info| info.group.clone())
+        .into_iter()
+        .filter_map(|(group, group_files)| {
+            let group_files: Vec<_> = group_files.collect();
 
-        let ra = my_files
-            .clone()
-            .into_iter()
-            .find(|(info, _)| info.read == "RA")
-            .unwrap_or_else(|| {
-                panic!(
-                    "couldn't find RA read for the following group:\n{:#?}\n The files found are: {:#?}",
-                    group, my_files
-                )
-            });
-        let i1 = my_files
-            .clone()
-            .into_iter()
-            .find(|(info, _)| info.read == "I1");
-        let i2 = my_files.into_iter().find(|(info, _)| info.read == "I2");
+            group_files
+                .iter()
+                // ignore groups that don't have an RA file
+                .find(|info| info.read == "RA")
+                .map(|ra| {
+                    let i1 = group_files.iter().find(|info| info.read == "I1");
+                    let i2 = group_files.iter().find(|info| info.read == "I2");
 
-        let fastqs = crate::read_pair_iter::InputFastqs {
-            r1: ra.1.to_str().unwrap().to_string(),
-            r2: None,
-            i1: i1.map(|x| x.1.to_str().unwrap().to_string()),
-            i2: i2.map(|x| x.1.to_str().unwrap().to_string()),
-            r1_interleaved: true,
-        };
-        (group, fastqs)
-    });
-    Ok(flowcell_fastqs.collect())
+                    let fastqs = crate::read_pair_iter::InputFastqs {
+                        r1: ra.path_string(),
+                        r2: None,
+                        i1: i1.map(BclProcessorFile::path_string),
+                        i2: i2.map(BclProcessorFile::path_string),
+                        r1_interleaved: true,
+                    };
+                    (group, fastqs)
+                })
+        })
+        .collect())
 }
 
-fn get_demux_files(path: &Path) -> Result<Vec<(BclProcessorFile, PathBuf)>> {
+fn get_demux_files(path: &Path) -> Result<Vec<BclProcessorFile>> {
     std::fs::read_dir(path)
         .with_context(|| path.display().to_string())?
-        .filter_map_ok(|x| try_parse(x.path()))
+        .filter_map_ok(|x| BclProcessorFile::new(&x.path()))
         .try_collect()
         .with_context(|| path.display().to_string())
-}
-
-fn try_parse(f: PathBuf) -> Option<(BclProcessorFile, PathBuf)> {
-    match f.file_name() {
-        Some(s) => {
-            let r = try_parse_bclprocessor_file(s.to_str().unwrap());
-            r.map(|v| (v, f))
-        }
-        None => None,
-    }
-}
-
-fn try_parse_bclprocessor_file(filename: &str) -> Option<BclProcessorFile> {
-    let re = "^read-([RI][A0-9])_si-([^_]+)_lane-([0-9]+)-chunk-([0-9]+).fastq(.gz|.lz4)?$";
-    let re = regex::Regex::new(re).unwrap();
-
-    re.captures(filename).map(|caps| BclProcessorFile {
-        path: PathBuf::from(filename),
-        read: caps.get(1).unwrap().as_str().to_string(),
-        group: BclProcessorFileGroup {
-            si: caps.get(2).unwrap().as_str().to_string(),
-            lane: caps.get(3).unwrap().as_str().parse().unwrap(),
-            chunk: caps.get(4).unwrap().as_str().parse().unwrap(),
-        },
-    })
 }
 
 #[cfg(test)]
@@ -250,10 +234,10 @@ mod tests {
     fn bcl_fn() {
         let f1 = "read-RA_si-TTAGCGAT_lane-002-chunk-001.fastq.gz";
 
-        let bcl = try_parse_bclprocessor_file(f1).unwrap();
+        let bcl = BclProcessorFile::new(Path::new(f1)).unwrap();
 
         let truth = BclProcessorFile {
-            path: PathBuf::from(f1),
+            full_path: PathBuf::from(f1),
             read: "RA".to_string(),
             group: BclProcessorFileGroup {
                 si: "TTAGCGAT".to_string(),
@@ -361,6 +345,18 @@ mod tests_from_tenkit {
         ];
 
         assert_eq!(fqs, expected);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_ra_missing() -> Result<()> {
+        let query = BclProcessorFastqDef {
+            fastq_path: "/mnt/analysis/marsoc/pipestances/HLVVHDSX3/BCL_PROCESSOR_PD/HLVVHDSX3/2020.0623.2-0/outs/fastq_path".to_string(),
+            sample_index_spec: "CTCAACCAGG".into(),
+            lane_spec: LaneSpec::Lanes(vec![1, 2].into_iter().collect()),
+        };
+        let _ = query.find_fastqs()?;
 
         Ok(())
     }

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -143,6 +143,7 @@ impl BclProcessorFile {
                 })
         })
     }
+
     fn path_string(&self) -> String {
         self.full_path.to_str().unwrap().to_string()
     }

--- a/src/filenames/bcl_processor.rs
+++ b/src/filenames/bcl_processor.rs
@@ -185,7 +185,12 @@ pub fn find_flowcell_fastqs(
             .clone()
             .into_iter()
             .find(|(info, _)| info.read == "RA")
-            .expect("couldn't find RA read");
+            .unwrap_or_else(|| {
+                panic!(
+                    "couldn't find RA read for the following group:\n{:#?}\n The files found are: {:#?}",
+                    group, my_files
+                )
+            });
         let i1 = my_files
             .clone()
             .into_iter()

--- a/src/sseq.rs
+++ b/src/sseq.rs
@@ -664,7 +664,7 @@ mod sseq_test {
         let seq = SSeq::from_bytes(b"ACGT");
         let _ = SSeq::from_iter(seq.as_bytes());
         let seq_vec = seq.as_bytes().to_vec();
-        let _ = SSeq::from_iter(seq_vec.into_iter());
+        let _ = SSeq::from_iter(seq_vec);
     }
 
     #[test]

--- a/tests/filenames/bcl_processor_3/read-I1_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
+++ b/tests/filenames/bcl_processor_3/read-I1_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
@@ -1,0 +1,1 @@
+../bcl_processor_2/read-I1_si-ACAGCAAC_lane-001-chunk-001.fastq.gz

--- a/tests/filenames/bcl_processor_3/read-I1_si-ACAGCAAC_lane-002-chunk-000.fastq.gz
+++ b/tests/filenames/bcl_processor_3/read-I1_si-ACAGCAAC_lane-002-chunk-000.fastq.gz
@@ -1,0 +1,1 @@
+../bcl_processor_2/read-I1_si-ACAGCAAC_lane-002-chunk-000.fastq.gz

--- a/tests/filenames/bcl_processor_3/read-I2_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
+++ b/tests/filenames/bcl_processor_3/read-I2_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
@@ -1,0 +1,1 @@
+../bcl_processor_2/read-I2_si-ACAGCAAC_lane-001-chunk-001.fastq.gz

--- a/tests/filenames/bcl_processor_3/read-I2_si-ACAGCAAC_lane-002-chunk-000.fastq.gz
+++ b/tests/filenames/bcl_processor_3/read-I2_si-ACAGCAAC_lane-002-chunk-000.fastq.gz
@@ -1,0 +1,1 @@
+../bcl_processor_2/read-I2_si-ACAGCAAC_lane-002-chunk-000.fastq.gz

--- a/tests/filenames/bcl_processor_3/read-RA_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
+++ b/tests/filenames/bcl_processor_3/read-RA_si-ACAGCAAC_lane-001-chunk-001.fastq.gz
@@ -1,0 +1,1 @@
+../bcl_processor_2/read-RA_si-ACAGCAAC_lane-001-chunk-001.fastq.gz


### PR DESCRIPTION
- Previous behavior was to panic.
- Refactor code to avoid using a tuple and some unnecessary clones.